### PR TITLE
Remove compass imports

### DIFF
--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -1,5 +1,3 @@
-@import 'compass/css3'
-@import 'compass'
 @import 'flexbox'
 
 $primary-font: #{"{{ theme.primary_font | font_family }}"}


### PR DESCRIPTION
Compass isn't used anywhere in the theme anymore, so we can remove it