### PR TITLE
feat: add settings for primary vs secondary badge text color

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -92,6 +92,7 @@
                     image-square
                   {% endif %}
                 {% endcapture %}
+                {% capture product-status-class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
                 <div class="product-list-thumb {{ product.css_class }}">
                   <a class="product-list-link" href="{{ product.url }}" title="View {{ product.name | escape }}">
                     <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -118,7 +119,7 @@
                       <div class="product-list-thumb-price">{{ product.default_price | money: theme.money_format }}</div>
                     </div>
                     {% if product_status != blank %}
-                      <div class="product-list-thumb-status">{{ product_status }}</div>
+                      <div class="product-list-thumb-status {{ product-status-class }}">{{ product_status }}</div>
                     {% endif %}
                   </a>
                 </div>

--- a/source/products.html
+++ b/source/products.html
@@ -35,6 +35,7 @@
                   image-square
                 {% endif %}
               {% endcapture %}
+              {% capture product-status-class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
               <div class="product-list-thumb {{ product.css_class }}">
                 <a class="product-list-link" href="{{ product.url }}" title="View {{ product.name | escape }}">
                   <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -61,7 +62,7 @@
                     <div class="product-list-thumb-price">{{ product.default_price | money: theme.money_format }}</div>
                   </div>
                   {% if product_status != blank %}
-                    <div class="product-list-thumb-status">{{ product_status }}</div>
+                    <div class="product-list-thumb-status {{ product-status-class }}">{{ product_status }}</div>
                   {% endif %}
                 </a>
               </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "images": [
     {
       "variable": "logo",
@@ -40,7 +40,10 @@
               "secondary_text_color": "#0B639A",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#0B639A",
-              "status_background_color": "#C43F06",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#C43F06",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#FF642A",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
@@ -62,7 +65,10 @@
               "secondary_text_color": "#F8F8F8",
               "button_text_color": "#141415",
               "button_background_color": "#F8F8F8",
-              "status_background_color": "#F8F8F8",
+              "badge_text_color_primary": "#222222",
+              "badge_background_color_primary": "#ffc65c",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#AEAEAE",
               "announcement_text_color": "#141415",
               "announcement_background_color": "#F8F8F8"
@@ -84,7 +90,10 @@
               "secondary_text_color": "#2A2A2C",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#2A2A2C",
-              "status_background_color": "#203BE1",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#203BE1",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#203BE1",
               "announcement_text_color": "#2A2A2C",
               "announcement_background_color": "#E3E4EA"
@@ -111,7 +120,10 @@
               "secondary_text_color": "#8A4942",
               "button_text_color": "#F5F4EE",
               "button_background_color": "#8A4942",
-              "status_background_color": "#898952",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#9a9a32",
+              "badge_text_color_secondary": "#262522",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#8A4942",
               "announcement_text_color": "#262522",
               "announcement_background_color": "#F1DBCE"
@@ -133,7 +145,10 @@
               "secondary_text_color": "#584B53",
               "button_text_color": "#FFFDFC",
               "button_background_color": "#584B53",
-              "status_background_color": "#9D5C63",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#9D5C63",
+              "badge_text_color_secondary": "#262522",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#9D5C63",
               "announcement_text_color": "#584B53",
               "announcement_background_color": "#D6E3F8"
@@ -159,9 +174,12 @@
               "primary_text_color": "#262626",
               "secondary_text_color": "#262626",
               "button_text_color": "#F6F7F2",
-              "button_background_color": "#C90304",
-              "status_background_color": "#F35900",
-              "link_hover_color": "#C90304",
+              "button_background_color": "#F35900",
+              "badge_text_color_primary": "#EFEFEF",
+              "badge_background_color_primary": "#F35900",
+              "badge_text_color_secondary": "#262626",
+              "badge_background_color_secondary": "#B7B7B7",
+              "link_hover_color": "#F35900",
               "announcement_text_color": "#F6F7F2",
               "announcement_background_color": "#F35900"
             }
@@ -175,14 +193,17 @@
             "colors": {
               "background_color": "#FFFFFF",
               "content_background_color": "#FFFFFF",
-              "accent_background_color": "#FFE500",
+              "accent_background_color": "#FFF795",
               "accent_text_color": "#0000FF",
               "accent_pattern_color": "#FFFFFF",
               "primary_text_color": "#0000FF",
               "secondary_text_color": "#0000FF",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#0000FF",
-              "status_background_color": "#FF0000",
+              "badge_text_color_primary": "#0000FF",
+              "badge_background_color_primary": "#FFD700",
+              "badge_text_color_secondary": "#262626",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#0000FF",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#0000FF"
@@ -204,7 +225,10 @@
               "secondary_text_color": "#243588",
               "button_text_color": "#243588",
               "button_background_color": "#ECD8FF",
-              "status_background_color": "#FFFA8D",
+              "badge_text_color_primary": "#243588",
+              "badge_background_color_primary": "#FFB4D9",
+              "badge_text_color_secondary": "#262626",
+              "badge_background_color_secondary": "#B7B7B7",
               "link_hover_color": "#F6248C",
               "announcement_text_color": "#243588",
               "announcement_background_color": "#FFFA8D"
@@ -259,27 +283,42 @@
     },
     {
       "variable": "secondary_text_color",
-      "label": "Secondary text color",
+      "label": "Secondary text",
       "default": "#0b639a"
     },
     {
       "variable": "button_text_color",
-      "label": "Button & status text color",
+      "label": "Button & status text",
       "default": "#FFFFFF"
     },
     {
       "variable": "button_background_color",
-      "label": "Button background color",
+      "label": "Button background",
       "default": "#0b639a"
     },
     {
-      "variable": "status_background_color",
-      "label": "Product status background color",
+      "variable": "badge_text_color_primary",
+      "label": "Badge text (primary)",
+      "default": "#FFFFFF"
+    },
+    {
+      "variable": "badge_background_color_primary",
+      "label": "Badge background (primary)",
       "default": "#C43F06"
     },
     {
+      "variable": "badge_text_color_secondary",
+      "label": "Badge text (secondary)",
+      "default": "#222222"
+    },
+    {
+      "variable": "badge_background_color_secondary",
+      "label": "Badge background (secondary)",
+      "default": "#B7B7B7"
+    },
+    {
       "variable": "link_hover_color",
-      "label": "Link hover color",
+      "label": "Link hover",
       "default": "#FF642A"
     },
     {
@@ -294,7 +333,7 @@
     }
   ],
   "options": [
-   {
+    {
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
       "type": "text",

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -23,7 +23,10 @@
   --button-background-color: #{"{{ theme.button_background_color }}"}
   --button-hover-background-color: #{'rgba(var(--button-background-color-rgb), .8)'}
 
-  --status-background-color: #{"{{ theme.status_background_color }}"}
+  --badge-text-color-primary: #{"{{ theme.badge_text_color_primary }}"}
+  --badge-background-color-primary: #{"{{ theme.badge_background_color_primary }}"}
+  --badge-text-color-secondary: #{"{{ theme.badge_text_color_secondary }}"}
+  --badge-background-color-secondary: #{"{{ theme.badge_background_color_secondary }}"}
   --link-hover-color: #{"{{ theme.link_hover_color }}"}
 
   --error-background-color: #950f1e

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -92,9 +92,7 @@
   +flexbox
   +align-items(center)
   +justify-content(center)
-  background: var(--status-background-color)
   font-size: 0.8rem
-  color: var(--button-text-color)
   font-style: normal
   font-weight: 500
   left: 16px
@@ -104,6 +102,14 @@
   text-transform: uppercase
   top: 16px
   white-space: nowrap
+
+  &.status-primary
+    background: var(--badge-background-color-primary)
+    color: var(--badge-text-color-primary)
+
+  &.status-secondary
+    background: var(--badge-background-color-secondary)
+    color: var(--badge-text-color-secondary)
 
 .no-results
   +flexbox


### PR DESCRIPTION
Also adjust defaults for styles to be more complimentary colors

Default style:
![image](https://github.com/user-attachments/assets/5fe69fc8-7946-4d06-b251-24314dca904e)

Playful style:
![image](https://github.com/user-attachments/assets/c653bd4d-9102-4012-a5da-90c054693792)
