### PR TITLE
feat: "all products" button after featured products on home

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -124,6 +124,11 @@
                 </div>
               {% endfor %}
             </div>
+            {% if paginate.pages > 1 %}
+              {% if theme.all_products_button_text != blank %}
+                <a class="button centered-button all-products-button" href="/products">{{ theme.all_products_button_text }}<svg aria-hidden="true" width="16" height="15" viewBox="0 0 21 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.445798 0l9.9966372 9.99663714-.0035344.00381736.0035344.0029084L10.445798 20l-1.87436943-1.8743695L15.1964286 11.5H0v-3h15.1964286L8.57142857 1.87436946z" fill-rule="evenodd"></path></svg></a>
+              {% endif %}
+            {% endif %}
         {% else %}
           <p class="no-results">No products found.</p>
         {% endif %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -378,6 +378,13 @@
       "description": "The number of items featured on the Home page"
     },
     {
+      "variable": "all_products_button_text",
+      "label": "All products button text",
+      "type": "text",
+      "description": "Displays underneath featured products and links to your Products Page",
+      "default": "View all products"
+    },
+    {
       "variable": "max_products_per_row",
       "label": "Maximum products per row",
       "type": "select",

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -70,3 +70,13 @@ section.content .products-page
 
   @media screen and (max-width: $break-small)
     padding: var(--small-padding)
+
+a.all-products-button
+  max-width: 350px
+  background: none
+  color: var(--primary-text-color)
+  border: 2px solid var(--primary-text-color)
+  gap: 12px
+
+  svg
+    fill: currentColor


### PR DESCRIPTION
Adds an "All Products" button (and corresponding setting for button caption text) if product catalog has more than the featured items.

![CleanShot 2024-11-17 at 19 12 34](https://github.com/user-attachments/assets/0b4b3622-f259-4c4f-959e-30cc0084f53e)