### PR TITLE
chore: add attributes for data hooks and page type in Layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -15,7 +15,7 @@
     <style>.preloader * { opacity: 0; }.transition-preloader * { transition: none !important }</style>
     {{ head_content }}
   </head>
-  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader">
+  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
     <a class="skip-link" href="#main">Skip to main content</a>
     {% if theme.announcement_message_text != blank %}
       <div aria-label="Announcement message" class="announcement-message">
@@ -28,7 +28,7 @@
       </div>
     {% endif %}
 
-    <header class="header">
+    <header class="header" data-bc-hook="header">
       <div class="wrapper">
 
         <div class="header-mobile-nav">
@@ -168,7 +168,7 @@
         {% endif %}
       </section>
     </main>
-    <footer class="footer">
+    <footer class="footer" data-bc-hook="footer">
       <div class="wrapper">
         <nav class="footernav" aria-label="Browse categories">
           <div class="footer-nav-title">

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranger",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
