### PR TITLE
Remove share buttons on product page

### DIFF
--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -95,32 +95,3 @@ function disableSelectOption(select_option, type) {
     }
   }
 }
-
-const shareButton = document.querySelector(".product-share-launch");
-const handleWebShare = () => {
-  const title = document.title;
-  const url = window.location.href;
-  navigator
-    .share({ title, url })
-    .catch((error) => console.error("Sharing failed:", error));
-}
-
-const toggleShareLinks = () => {
-  const shareLinks = document.querySelector(".product-share-buttons");
-
-  if (shareLinks) {
-    const isHidden = shareLinks.getAttribute("aria-hidden") === "true";
-    shareLinks.setAttribute("aria-hidden", isHidden ? "false" : "true");
-    shareButton.setAttribute("aria-expanded", isHidden ? "true" : "false");
-  }
-}
-
-if (shareButton) {
-  shareButton.addEventListener("click", () => {
-    if (navigator.share) {
-      handleWebShare();
-    } else {
-      toggleShareLinks();
-    }
-  });
-}

--- a/source/layout.html
+++ b/source/layout.html
@@ -408,7 +408,6 @@
       <script>
         Product.find('{{ product.permalink }}', processProduct)
       </script>
-      <script async defer src="//assets.pinterest.com/js/pinit.js"></script>
     {% endif %}
   </body>
 </html>

--- a/source/product.html
+++ b/source/product.html
@@ -196,36 +196,6 @@
       {% if product.description != blank %}
         <div class="product-detail__description">{{ product.description | paragraphs }}</div>
       {% endif %}
-      {% if theme.share_buttons %}
-        <div class="product-detail__share">
-          <button class="product-share-launch">
-            <svg aria-hidden="true" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><path d="m8.5 4c.27614 0 .5.22386.5.5 0 .24545778-.17687704.4496079-.41012499.49194425l-.08987501.00805575h-3c-.77969882 0-1.420449.59488554-1.49313345 1.35553954l-.00686655.14446046v8c0 .7796706.59488554 1.4204457 1.35553954 1.4931332l.14446046.0068668h8c.7796706 0 1.4204457-.5949121 1.4931332-1.3555442l.0068668-.1444558v-1c0-.2761.2239-.5.5-.5.2454222 0 .4496.1769086.4919429.4101355l.0080571.0898645v1c0 1.325472-1.0315469 2.4100378-2.3356256 2.4946823l-.1643744.0053177h-8c-1.3254816 0-2.41003853-1.0315469-2.49468231-2.3356256l-.00531769-.1643744v-8c0-1.3254816 1.03153766-2.41003853 2.33562452-2.49468231l.16437548-.00531769zm4.768-.89136.0617.05301 4.4971 4.42118c.2099.20633.229.53775.0573.76685l-.0572.06544-4.4971 4.42258c-.3378.3322-.8869.1189-.9469-.3338l-.0053-.0823v-2.0955l-.2577.0232c-1.8003.1924-3.52574 1.0235-5.18729 2.5071-.38943.3478-.99194.019-.92789-.5063.49872-4.09021 2.58567-6.34463 6.14828-6.62742l.2246-.01511v-2.12975c0-.47977.5302-.73818.8904-.46918z" /></svg>
-            <span>Share <span class="visually-hidden">this product</span></span>
-          </button>
-          <ul id="product-share-buttons" class="product-share-buttons" aria-hidden="true">
-            <li class="social-twitter">
-              {% capture tweet_string %}{{ product.name }} - {{ store.name }} {{ page.full_url }}{% endcapture %}
-              {% assign tweet_string = tweet_string | url_encode %}
-              <a title="Tweet" href="https://twitter.com/intent/tweet?text={{ tweet_string }}" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=no,scrollbars=no,height=400,width=600');return false;">
-                <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 150.857 612 490.298"><path d="M606 209c-22.2 9.7-46 16.4-70.8 19.4 25.4-15.3 45-39.6 54-68.5-23.7 14-50 24-78 30-22.5-24-54.4-39-89.8-39-68 0-123 55-123 123 0 9.3 1 19 3 28-102.2-5-192.8-54-253.4-129-11 18.3-17 39.5-17 62.2 0 43 21.5 81 54.6 103-20.2-.6-39.2-6-55.8-15.4v2c0 60 42.3 110 98.6 121.2-10.4 3-21.3 4.6-32.5 4.6-8 0-16-1-23-2.5 15 49.3 61 85 115 86-42 33.3-96 53-153 53-10 0-20-.5-30-1.7 55 35 119.5 55.5 189 55.5 226.3 0 350-188.5 350-352 0-5.5 0-10.8-.3-16 24-17.6 45-39.4 61.4-64z"/></svg>
-                <span>Twitter</span>
-              </a>
-            </li>
-            <li class="social-facebook">
-              <a title="Share on Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{store.url}}{{product.url}}" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=no,scrollbars=no,height=400,width=600');return false;">
-                <svg class="facebook-icon" height="36" width="36" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 19.91 20"><path d="M23.9 5H6.1C5.5 5 5 5.5 5 6.1v17.7c0 .7.5 1.2 1.1 1.2h9.5v-7.7H13v-3h2.6V12c0-2.6 1.6-4 3.9-4 1.1 0 2 .1 2.3.1v2.7h-1.6c-1.2 0-1.5.6-1.5 1.5v1.9h3l-.4 3h-2.6V25h5.1c.6 0 1.1-.5 1.1-1.1V6.1c.1-.6-.4-1.1-1-1.1z"></path></svg>
-                <span>Facebook</span>
-              </a>
-            </li>
-            <li class="social-pinterest">
-              <a title="Pin" tabindex="-1" data-pin-custom="true" data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/?url={{ page.full_url }}&media={{ product.images.first.url }}&description={{ product.description | escape | truncate: 200 }}">
-                <svg class="pinterest-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M496 256c0 137-111 248-248 248-25.6 0-50.2-3.9-73.4-11.1 10.1-16.5 25.2-43.5 30.8-65 3-11.6 15.4-59 15.4-59 8.1 15.4 31.7 28.5 56.8 28.5 74.8 0 128.7-68.8 128.7-154.3 0-81.9-66.9-143.2-152.9-143.2-107 0-163.9 71.8-163.9 150.1 0 36.4 19.4 81.7 50.3 96.1 4.7 2.2 7.2 1.2 8.3-3.3.8-3.4 5-20.3 6.9-28.1.6-2.5.3-4.7-1.7-7.1-10.1-12.5-18.3-35.3-18.3-56.6 0-54.7 41.4-107.6 112-107.6 60.9 0 103.6 41.5 103.6 100.9 0 67.1-33.9 113.6-78 113.6-24.3 0-42.6-20.1-36.7-44.8 7-29.5 20.5-61.3 20.5-82.6 0-19-10.2-34.9-31.4-34.9-24.9 0-44.9 25.7-44.9 60.2 0 22 7.4 36.8 7.4 36.8s-24.5 103.8-29 123.2c-5 21.4-3 51.6-.9 71.2C65.4 450.9 0 361.1 0 256 0 119 111 8 248 8s248 111 248 248z"></path></svg>
-                <span>Pinterest</span>
-              </a>
-            </li>
-          </ul>
-        </div>
-      {% endif %}
     </section>
   </div>
 </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -490,13 +490,6 @@
       "description": "Choose to hide or show thumbnails on the mobile Product page carousel"
     },
     {
-      "variable": "share_buttons",
-      "label": "Show product share button",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds a Share button to your Product page after the description"
-    },
-    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
       "type": "boolean",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -87,7 +87,7 @@ section.content
     font-size: .875em
     line-height: normal
     display: inline-block
-  
+
   &__separator
     margin: 0 8px
 
@@ -130,51 +130,3 @@ section.content
 
 #instant-checkout-button
   margin-top: 12px
-
-.product-detail__share
-  position: relative
-
-  .product-share-launch
-    display: flex
-    align-items: center
-    justify-content: center
-    gap: 6px
-
-    &:hover
-      color: var(--link-hover-color)
-
-      span
-        text-decoration: underline
-        text-underline-offset: 4px
-
-    svg
-      height: 22px
-      width: 22px
-      fill: currentColor
-
-  .product-share-buttons
-    display: none
-    gap: 16px
-    position: absolute
-    background: var(--content-background-color)
-    border: 2px solid var(--border-color)
-    top: calc(100% + 4px)
-    padding: 12px
-    font-size: .925em
-    flex-direction: column
-
-    li a
-      display: flex
-      gap: 12px
-      align-items: center
-
-    &[aria-hidden="false"]
-      display: flex
-
-    a:hover
-      color: var(--link-hover-color)
-
-    svg
-      fill: currentColor
-      height: 16px
-      width: 16px


### PR DESCRIPTION
Engagement on these types of Share buttons continues to decrease year over year, so the buttons are being removed. Instead, visitors can copy/paste URLs, use browser plugins, or use the native share tools on mobile browsers.