### PR TITLE
v2.4.0

### DIFF
--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -32,6 +32,65 @@ $('.product-option-select').on('change',function() {
   var option_price = $(this).find("option:selected").attr("data-price");
   enableAddButton(option_price);
 });
+
+function updateInventoryMessage(optionId = null) {
+  const product = window.bigcartel.product;
+  const messageElement = document.querySelector('[data-inventory-message]');
+
+  if (
+    !themeOptions?.showLowInventoryMessages ||
+    !messageElement
+  ) {
+    return;
+  }
+
+  messageElement.textContent = '';
+  const productOptions = product?.options || [];
+
+  // If no option is selected (initial page load or reset) or product has no options
+  if (!optionId) {
+    const hasOptionWithStatus = (status) => 
+      productOptions.length > 0 && 
+      productOptions.some(option => 
+        option && 
+        !option.sold_out && 
+        option[status]
+      );
+
+    // Single option product - check both statuses
+    if (productOptions.length === 1) {
+      const option = productOptions[0];
+      if (option && !option.sold_out) {
+        if (option.isAlmostSoldOut) {
+          messageElement.textContent = themeOptions.almostSoldOutMessage;
+        } else if (option.isLowInventory) {
+          messageElement.textContent = themeOptions.lowInventoryMessage;
+        }
+      }
+      return;
+    }
+
+    // Multiple options - only check for low inventory across all options
+    if (productOptions.length > 1 && hasOptionWithStatus('isLowInventory')) {
+      messageElement.textContent = themeOptions.lowInventoryMessage;
+    }
+    return;
+  }
+
+  // Handle selected option
+  const selectedOption = product.options.find(option => option.id === parseInt(optionId));
+  if (!selectedOption || selectedOption.sold_out) return;
+
+  // For selected options:
+  // - Single option products: check both almost sold out and low inventory
+  // - Multiple option products: check both statuses when specific option selected
+  if (selectedOption.isAlmostSoldOut) {
+    messageElement.textContent = themeOptions.almostSoldOutMessage;
+  } else if (selectedOption.isLowInventory) {
+    messageElement.textContent = themeOptions.lowInventoryMessage;
+  }
+}
+
 function enableAddButton(updated_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
@@ -44,6 +103,7 @@ function enableAddButton(updated_price) {
   }
   addButton.html(addButtonTitle + priceTitle);
   addButton.attr('aria-label',addButton.text());
+  updateInventoryMessage($('#option').val());
 }
 
 function disableAddButton(type) {
@@ -95,3 +155,7 @@ function disableSelectOption(select_option, type) {
     }
   }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateInventoryMessage();
+});

--- a/source/layout.html
+++ b/source/layout.html
@@ -290,7 +290,7 @@
             </ul>
           </nav>
 
-          <nav aria-label="Pages">
+          <nav class="mobile-navigation__custom-pages" aria-label="Pages">
             <ul class="mobile-navigation__links">
               {% for page in pages.all %}
                 <li>{{ page | link_to }}</li>

--- a/source/layout.html
+++ b/source/layout.html
@@ -169,15 +169,22 @@
       </section>
     </main>
     <footer class="footer" data-bc-hook="footer">
+      {% if theme.footer_text != blank and theme.footer_text_position == "start" %}
+        <div class="footer-custom-content">{{ theme.footer_text }} </div>
+      {% endif %}
       <div class="wrapper">
         <nav class="footernav" aria-label="Browse categories">
           <div class="footer-nav-title">
-            <a href="/products">{% if theme.collections %}Collections{% else %}{{ pages.products.name }}{% endif %}</a>
+            Shop
           </div>
           <ul>
-            {% for category in categories.active %}
-              <li>{{ category | link_to }}</li>
-            {% endfor %}
+            <li><a href="/">{{ pages.home.name }}</a></li>
+            <li><a href="/products">{% if theme.collections %}Collections{% else %}{{ pages.products.name }}{% endif %}</a></li>
+            {% if theme.show_categories_in_footer %}
+              {% for category in categories.active %}
+                <li>{{ category | link_to }}</li>
+              {% endfor %}
+            {% endif %}
           </ul>
         </nav>
         <nav class="footernav" aria-label="Pages">
@@ -264,8 +271,12 @@
             </ul>
           </nav>
         {% endif %}
-        <div class="credit-container">{{ powered_by_big_cartel }}</div>
+        <div class="credit-container credit-container--primary">{{ powered_by_big_cartel }}</div>
       </div>
+      {% if theme.footer_text != blank and theme.footer_text_position == "end" %}
+        <div class="footer-custom-content">{{ theme.footer_text }} </div>
+      {% endif %}
+      <div class="credit-container credit-container--secondary">{{ powered_by_big_cartel }}</div>
     </footer>
     {% if theme.show_search %}
       <div id="search-modal" class="search-modal" role="dialog" aria-modal="true" aria-hidden="true">
@@ -308,9 +319,6 @@
                 <li>{{ page | link_to }}</li>
               {% endfor %}
               <li><a href="/contact">{{ pages.contact.name }}</a></li>
-              {% if store.website != blank %}
-                <li><a href="{{ store.website }}">Back to site</a></li>
-              {% endif %}
             </ul>
           </nav>
 

--- a/source/layout.html
+++ b/source/layout.html
@@ -203,6 +203,7 @@
           or theme.youtube_url != blank
           or theme.spotify_url != blank
           or theme.linkedin_url != blank
+          or theme.twitch_url != blank
           or theme.tumblr_url != blank
           or theme.bandcamp_url != blank %}
           <nav class="footernav" aria-label="Social links">
@@ -250,6 +251,10 @@
 
               {% if theme.linkedin_url != blank %}
                 <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>LinkedIn</a></li>
+              {% endif %}
+
+              {% if theme.twitch_url != blank %}
+                <li><a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg>Twitch</a></li>
               {% endif %}
 
               {% if theme.tumblr_url != blank %}
@@ -323,6 +328,7 @@
             or theme.youtube_url != blank
             or theme.spotify_url != blank
             or theme.linkedin_url != blank
+            or theme.twitch_url != blank
             or theme.tumblr_url != blank
             or theme.bandcamp_url != blank %}
             <nav aria-label="Social links">
@@ -369,6 +375,10 @@
 
                 {% if theme.linkedin_url != blank %}
                   <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
+                {% endif %}
+
+                {% if theme.twitch_url != blank %}
+                  <li><a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a></li>
                 {% endif %}
 
                 {% if theme.tumblr_url != blank %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -412,6 +412,9 @@
       }
       const themeOptions = {
         showSoldOutOptions: {{ theme.show_sold_out_product_options }},
+        showLowInventoryMessages: {{ theme.show_low_inventory_messages }},
+        lowInventoryMessage: '{{ theme.low_inventory_message }}',
+        almostSoldOutMessage: '{{ theme.almost_sold_out_message }}',
         desktopProductPageImages: '{{ theme.desktop_product_page_images }}',
         mobileProductPageImages: '{{ theme.mobile_product_page_images }}',
         productImageZoom: {{ theme.product_image_zoom }},

--- a/source/layout.html
+++ b/source/layout.html
@@ -201,6 +201,8 @@
           or theme.facebook_url != blank
           or theme.pinterest_url != blank
           or theme.youtube_url != blank
+          or theme.spotify_url != blank
+          or theme.linkedin_url != blank
           or theme.tumblr_url != blank
           or theme.bandcamp_url != blank %}
           <nav class="footernav" aria-label="Social links">
@@ -240,6 +242,14 @@
 
               {% if theme.youtube_url != blank %}
                 <li><a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg>YouTube</a></li>
+              {% endif %}
+
+              {% if theme.spotify_url != blank %}
+                <li><a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg>Spotify</a></li>
+              {% endif %}
+
+              {% if theme.linkedin_url != blank %}
+                <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>LinkedIn</a></li>
               {% endif %}
 
               {% if theme.tumblr_url != blank %}
@@ -311,6 +321,8 @@
             or theme.facebook_url != blank
             or theme.pinterest_url != blank
             or theme.youtube_url != blank
+            or theme.spotify_url != blank
+            or theme.linkedin_url != blank
             or theme.tumblr_url != blank
             or theme.bandcamp_url != blank %}
             <nav aria-label="Social links">
@@ -349,6 +361,14 @@
 
                 {% if theme.youtube_url != blank %}
                   <li><a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg></a></li>
+                {% endif %}
+
+                {% if theme.spotify_url != blank %}
+                  <li><a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a></li>
+                {% endif %}
+
+                {% if theme.linkedin_url != blank %}
+                  <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
                 {% endif %}
 
                 {% if theme.tumblr_url != blank %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -187,9 +187,6 @@
               <li>{{ page | link_to }}</li>
             {% endfor %}
             <li><a href="/contact">{{ pages.contact.name }}</a></li>
-            {% if store.website != blank %}
-              <li><a href="{{ store.website }}">Back to site</a></li>
-            {% endif %}
           </ul>
         </nav>
         {% if theme.instagram_url != blank

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -25,6 +25,7 @@
         or theme.youtube_url != blank
         or theme.spotify_url != blank
         or theme.linkedin_url != blank
+        or theme.twitch_url != blank
         or theme.tumblr_url != blank
         or theme.bandcamp_url != blank %}
         <ul class="social-icons">
@@ -70,6 +71,10 @@
 
           {% if theme.linkedin_url != blank %}
             <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
+          {% endif %}
+
+          {% if theme.twitch_url != blank %}
+            <li><a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a></li>
           {% endif %}
 
           {% if theme.tumblr_url != blank %}

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -23,6 +23,8 @@
         or theme.facebook_url != blank
         or theme.pinterest_url != blank
         or theme.youtube_url != blank
+        or theme.spotify_url != blank
+        or theme.linkedin_url != blank
         or theme.tumblr_url != blank
         or theme.bandcamp_url != blank %}
         <ul class="social-icons">
@@ -60,6 +62,14 @@
 
           {% if theme.youtube_url != blank %}
             <li><a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg></a></li>
+          {% endif %}
+
+          {% if theme.spotify_url != blank %}
+            <li><a href="{{ theme.spotify_url }}" title="Spotify"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a></li>
+          {% endif %}
+
+          {% if theme.linkedin_url != blank %}
+            <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
           {% endif %}
 
           {% if theme.tumblr_url != blank %}

--- a/source/product.html
+++ b/source/product.html
@@ -210,22 +210,27 @@
       Step 1: Collect Products from Categories
       {% endcomment %}
       {% if product.categories != blank %}
-        {% for category in product.categories limit: 4 %}
-          {% for product in category.products | order: theme.related_products_order %}
-            {% if final_product_permalinks | split: ',' | size < related_products_limit %}
-              {% assign product_permalink = product.permalink %}
-              {% if product.id != current_id %}
-                {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-                {% unless product_permalinks_array contains product_permalink %}
-                  {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-                {% endunless %}
-              {% endif %}
-            {% else %}
-              {% break %}
-            {% endif %}
-          {% endfor %}
+      {% for category in product.categories limit: 4 %}
+        {% if current_count >= related_products_limit %}
+          {% break %}
+        {% endif %}
+        
+        {% for product in category.products | order: theme.related_products_order %}
+          {% if current_count >= related_products_limit %}
+            {% break %}
+          {% endif %}
+          
+          {% assign product_permalink = product.permalink %}
+          {% if product.id != current_id %}
+            {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+            {% unless product_permalinks_array contains product_permalink %}
+              {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+              {% assign current_count = current_count | plus: 1 %}
+            {% endunless %}
+          {% endif %}
         {% endfor %}
-      {% endif %}
+      {% endfor %}
+    {% endif %}
       
       {% comment %}
       Step 2: Collect Fallback Products from products.all

--- a/source/product.html
+++ b/source/product.html
@@ -203,74 +203,76 @@
     {% assign related_products_header = theme.related_products_header | default: 'You might also like' %}
     {% assign related_products_collection = product.related_products %}  
   
-    <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
-      <div class="related-products-header">
-        <h2 class="related-products-title">{{ related_products_header }}</h2>
-        <a class="related-products-view-all-link" href="/products">View all products</a>
-      </div>
-      <div class="product-list-container">
-        <div class="related-product-list product-list">
-          {% for related_product in related_products_collection %}
-            {% assign image_width = related_product.image.width | times: 1.0 %}
-            {% assign image_height = related_product.image.height | times: 1.0 %}
-            {% assign aspect_ratio = image_width | divided_by: image_height %}
-            {% assign related_product_status = '' %}
-            {% case related_product.status %}
-              {% when 'active' %}
-                {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %}
-              {% when 'sold-out' %}
-                {% assign related_product_status = 'Sold out' %}
-              {% when 'coming-soon' %}
-                {% assign related_product_status = 'Coming soon' %}
-            {% endcase %}
-            {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-            {% capture image_class %}
-              {% if related_product.image.height > related_product.image.width %}
-                image-tall
-              {% elsif related_product.image.height < related_product.image.width %}
-                image-wide
-              {% else %}
-                image-square
-              {% endif %}
-            {% endcapture %}
-            <div class="product-list-thumb {{ related_product.css_class }}">
-              <a class="product-list-link" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
-                <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                  <img
-                    alt=""
-                    class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                    src="{{ related_product.image | product_image_url | constrain: 20 }}"
-                    {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
-                    data-srcset="
-                      {{ related_product.image | product_image_url | constrain: 240 }} 240w,
-                      {{ related_product.image | product_image_url | constrain: 320 }} 320w,
-                      {{ related_product.image | product_image_url | constrain: 400 }} 400w,
-                      {{ related_product.image | product_image_url | constrain: 540 }} 540w,
-                      {{ related_product.image | product_image_url | constrain: 600 }} 600w,
-                      {{ related_product.image | product_image_url | constrain: 800 }} 800w,
-                      {{ related_product.image | product_image_url | constrain: 960 }} 960w
-                    "
-                    data-sizes="auto"
-                  >
-                  {% if related_product_status != blank %}<div class="product-list-thumb-status {{ related_product_status_class }}">{{ related_product_status }}</div>{% endif %}
-                </div>
-                <div class="product-list-thumb-info">
-                  <div class="product-list-thumb-name">{{ related_product.name }}</div>
-                  <div class="product-list-thumb-price">
-                    {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                      {% if related_product.variable_pricing %}
-                        {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
-                      {% else %}
-                        {{ related_product.default_price | money: theme.money_format }}
-                      {% endif %}
-                    {% endunless %}
-                  </div>
-                </div>
-              </a>
-            </div>
-          {% endfor %}
+    {% if related_products_collection.size > 0 %}
+      <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
+        <div class="related-products-header">
+          <h2 class="related-products-title">{{ related_products_header }}</h2>
+          <a class="related-products-view-all-link" href="/products">View all products</a>
         </div>
-      </div>
-    </aside>
+        <div class="product-list-container">
+          <div class="related-product-list product-list">
+            {% for related_product in related_products_collection %}
+              {% assign image_width = related_product.image.width | times: 1.0 %}
+              {% assign image_height = related_product.image.height | times: 1.0 %}
+              {% assign aspect_ratio = image_width | divided_by: image_height %}
+              {% assign related_product_status = '' %}
+              {% case related_product.status %}
+                {% when 'active' %}
+                  {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %}
+                {% when 'sold-out' %}
+                  {% assign related_product_status = 'Sold out' %}
+                {% when 'coming-soon' %}
+                  {% assign related_product_status = 'Coming soon' %}
+              {% endcase %}
+              {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+              {% capture image_class %}
+                {% if related_product.image.height > related_product.image.width %}
+                  image-tall
+                {% elsif related_product.image.height < related_product.image.width %}
+                  image-wide
+                {% else %}
+                  image-square
+                {% endif %}
+              {% endcapture %}
+              <div class="product-list-thumb {{ related_product.css_class }}">
+                <a class="product-list-link" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+                  <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                    <img
+                      alt=""
+                      class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                      src="{{ related_product.image | product_image_url | constrain: 20 }}"
+                      {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
+                      data-srcset="
+                        {{ related_product.image | product_image_url | constrain: 240 }} 240w,
+                        {{ related_product.image | product_image_url | constrain: 320 }} 320w,
+                        {{ related_product.image | product_image_url | constrain: 400 }} 400w,
+                        {{ related_product.image | product_image_url | constrain: 540 }} 540w,
+                        {{ related_product.image | product_image_url | constrain: 600 }} 600w,
+                        {{ related_product.image | product_image_url | constrain: 800 }} 800w,
+                        {{ related_product.image | product_image_url | constrain: 960 }} 960w
+                      "
+                      data-sizes="auto"
+                    >
+                    {% if related_product_status != blank %}<div class="product-list-thumb-status {{ related_product_status_class }}">{{ related_product_status }}</div>{% endif %}
+                  </div>
+                  <div class="product-list-thumb-info">
+                    <div class="product-list-thumb-name">{{ related_product.name }}</div>
+                    <div class="product-list-thumb-price">
+                      {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                        {% if related_product.variable_pricing %}
+                          {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
+                        {% else %}
+                          {{ related_product.default_price | money: theme.money_format }}
+                        {% endif %}
+                      {% endunless %}
+                    </div>
+                  </div>
+                </a>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      </aside>
+    {% endif %}
   {% endif %}
 </div>

--- a/source/product.html
+++ b/source/product.html
@@ -207,7 +207,7 @@
       <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
         <div class="related-products-header">
           <h2 class="related-products-title">{{ related_products_header }}</h2>
-          <a class="related-products-view-all-link" href="/products">View all products</a>
+          <a class="related-products-view-all-link" href="/products">View all</a>
         </div>
         <div class="product-list-container">
           <div class="related-product-list product-list">

--- a/source/product.html
+++ b/source/product.html
@@ -186,6 +186,7 @@
           {% endif %}
           <button class="button add-to-cart-button" name="submit" type="submit" data-add-title="Add to cart" data-sold-title="Sold out">Add to cart</button>
           {{ store | instant_checkout_button: 'dark', '44px' }}
+          <div class="inventory-status-message" data-inventory-message></div>
           {% if product.has_option_groups %}
             <div class="reset-selection-button-container">
               <button class="button minimal-button reset-selection-button" type="reset">Reset selection</button>

--- a/source/product.html
+++ b/source/product.html
@@ -198,4 +198,134 @@
       {% endif %}
     </section>
   </div>
+
+
+  {% if page.full_url contains '/product/' %}
+    {% if theme.show_related_products %}
+      {% assign current_id = product.id | to_string %}
+      {% assign related_products_limit = theme.related_products | default: 4 %}
+      {% assign final_product_permalinks = '' %}
+      
+      {% comment %}
+      Step 1: Collect Products from Categories
+      {% endcomment %}
+      {% if product.categories != blank %}
+        {% for category in product.categories limit: 4 %}
+          {% for product in category.products | order: theme.related_products_order %}
+            {% if final_product_permalinks | split: ',' | size < related_products_limit %}
+              {% assign product_permalink = product.permalink %}
+              {% if product.id != current_id %}
+                {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+                {% unless product_permalinks_array contains product_permalink %}
+                  {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+                {% endunless %}
+              {% endif %}
+            {% else %}
+              {% break %}
+            {% endif %}
+          {% endfor %}
+        {% endfor %}
+      {% endif %}
+      
+      {% comment %}
+      Step 2: Collect Fallback Products from products.all
+      {% endcomment %}
+      {% assign current_count = final_product_permalinks | split: ',' | size %}
+      {% assign remaining_limit = related_products_limit | minus: current_count %}
+      
+      {% if remaining_limit > 0 %}
+        {% paginate products from products.all by remaining_limit order: theme.related_products_order %}
+          {% for product in products %}
+            {% assign product_permalink = product.permalink %}
+            {% if product.id != current_id %}
+              {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+              {% unless product_permalinks_array contains product_permalink %}
+                {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+              {% endunless %}
+            {% endif %}
+          {% endfor %}
+        {% endpaginate %}
+      {% endif %}
+      
+      {% comment %}
+      Step 3: Render Final Products
+      {% endcomment %}
+      {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
+      {% if final_permalinks_array.size > 0 %}
+        <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.related_products_header | default: 'You might also like' }}">
+          <div class="related-products-header">
+            <h2 class="related-products-title">{{ theme.related_products_header | default: 'You might also like' }}</h2>
+            <a class="related-products-view-all-link" href="/products">View all products</a>
+          </div>
+          <div class="product-list-container">
+            <div class="related-product-list product-list">
+              {% for product_permalink in final_permalinks_array %}
+                {% assign matched_product = products[product_permalink] %}
+                
+                {% if matched_product != blank %}
+                  {% assign image_width = matched_product.image.width | times: 1.0 %}
+                  {% assign image_height = matched_product.image.height | times: 1.0 %}
+                  {% assign aspect_ratio = image_width | divided_by: image_height %}
+                  {% assign matched_product_status = '' %}
+                  {% case matched_product.status %}
+                    {% when 'active' %}
+                      {% if matched_product.on_sale %}{% assign matched_product_status = 'On sale' %}{% endif %}
+                    {% when 'sold-out' %}
+                      {% assign matched_product_status = 'Sold out' %}
+                    {% when 'coming-soon' %}
+                      {% assign matched_product_status = 'Coming soon' %}
+                  {% endcase %}
+                  {% capture matched_product_status_class %}{% if matched_product.status == 'active' and matched_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+                  {% capture image_class %}
+                    {% if matched_product.image.height > matched_product.image.width %}
+                      image-tall
+                    {% elsif matched_product.image.height < matched_product.image.width %}
+                      image-wide
+                    {% else %}
+                      image-square
+                    {% endif %}
+                  {% endcapture %}
+                  <div class="product-list-thumb {{ matched_product.css_class }}">
+                    <a class="product-list-link" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
+                      <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                        <img
+                          alt=""
+                          class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                          src="{{ matched_product.image | product_image_url | constrain: 20 }}"
+                          {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
+                          data-srcset="
+                            {{ matched_product.image | product_image_url | constrain: 240 }} 240w,
+                            {{ matched_product.image | product_image_url | constrain: 320 }} 320w,
+                            {{ matched_product.image | product_image_url | constrain: 400 }} 400w,
+                            {{ matched_product.image | product_image_url | constrain: 540 }} 540w,
+                            {{ matched_product.image | product_image_url | constrain: 600 }} 600w,
+                            {{ matched_product.image | product_image_url | constrain: 800 }} 800w,
+                            {{ matched_product.image | product_image_url | constrain: 960 }} 960w
+                          "
+                          data-sizes="auto"
+                        >
+                        {% if matched_product_status != blank %}<div class="product-list-thumb-status {{ matched_product_status_class }}">{{ matched_product_status }}</div>{% endif %}
+                      </div>
+                      <div class="product-list-thumb-info">
+                        <div class="product-list-thumb-name">{{ matched_product.name }}</div>
+                        <div class="product-list-thumb-price">
+                          {% unless matched_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                            {% if matched_product.variable_pricing %}
+                              {{ matched_product.min_price | money: theme.money_format }} - {{ matched_product.max_price | money: theme.money_format }}
+                            {% else %}
+                              {{ matched_product.default_price | money: theme.money_format }}
+                            {% endif %}
+                          {% endunless %}
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                {% endif %}
+              {% endfor %}
+            </div>
+          </div>
+        </aside>
+      {% endif %}
+    {% endif %}
+  {% endif %}
 </div>

--- a/source/product.html
+++ b/source/product.html
@@ -199,138 +199,78 @@
     </section>
   </div>
 
-
-  {% if page.full_url contains '/product/' %}
-    {% if theme.show_related_products %}
-      {% assign current_id = product.id | to_string %}
-      {% assign related_products_limit = theme.related_products | default: 4 %}
-      {% assign final_product_permalinks = '' %}
-      
-      {% comment %}
-      Step 1: Collect Products from Categories
-      {% endcomment %}
-      {% if product.categories != blank %}
-      {% for category in product.categories limit: 4 %}
-        {% if current_count >= related_products_limit %}
-          {% break %}
-        {% endif %}
-        
-        {% for product in category.products | order: theme.related_products_order %}
-          {% if current_count >= related_products_limit %}
-            {% break %}
-          {% endif %}
-          
-          {% assign product_permalink = product.permalink %}
-          {% if product.id != current_id %}
-            {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-            {% unless product_permalinks_array contains product_permalink %}
-              {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-              {% assign current_count = current_count | plus: 1 %}
-            {% endunless %}
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
-    {% endif %}
-      
-      {% comment %}
-      Step 2: Collect Fallback Products from products.all
-      {% endcomment %}
-      {% assign current_count = final_product_permalinks | split: ',' | size %}
-      {% assign remaining_limit = related_products_limit | minus: current_count %}
-      
-      {% if remaining_limit > 0 %}
-        {% paginate products from products.all by remaining_limit order: theme.related_products_order %}
-          {% for product in products %}
-            {% assign product_permalink = product.permalink %}
-            {% if product.id != current_id %}
-              {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-              {% unless product_permalinks_array contains product_permalink %}
-                {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-              {% endunless %}
-            {% endif %}
-          {% endfor %}
-        {% endpaginate %}
-      {% endif %}
-      
-      {% comment %}
-      Step 3: Render Final Products
-      {% endcomment %}
-      {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
-      {% if final_permalinks_array.size > 0 %}
-        <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.related_products_header | default: 'You might also like' }}">
-          <div class="related-products-header">
-            <h2 class="related-products-title">{{ theme.related_products_header | default: 'You might also like' }}</h2>
-            <a class="related-products-view-all-link" href="/products">View all products</a>
-          </div>
-          <div class="product-list-container">
-            <div class="related-product-list product-list">
-              {% for product_permalink in final_permalinks_array %}
-                {% assign matched_product = products[product_permalink] %}
-                
-                {% if matched_product != blank %}
-                  {% assign image_width = matched_product.image.width | times: 1.0 %}
-                  {% assign image_height = matched_product.image.height | times: 1.0 %}
-                  {% assign aspect_ratio = image_width | divided_by: image_height %}
-                  {% assign matched_product_status = '' %}
-                  {% case matched_product.status %}
-                    {% when 'active' %}
-                      {% if matched_product.on_sale %}{% assign matched_product_status = 'On sale' %}{% endif %}
-                    {% when 'sold-out' %}
-                      {% assign matched_product_status = 'Sold out' %}
-                    {% when 'coming-soon' %}
-                      {% assign matched_product_status = 'Coming soon' %}
-                  {% endcase %}
-                  {% capture matched_product_status_class %}{% if matched_product.status == 'active' and matched_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-                  {% capture image_class %}
-                    {% if matched_product.image.height > matched_product.image.width %}
-                      image-tall
-                    {% elsif matched_product.image.height < matched_product.image.width %}
-                      image-wide
-                    {% else %}
-                      image-square
-                    {% endif %}
-                  {% endcapture %}
-                  <div class="product-list-thumb {{ matched_product.css_class }}">
-                    <a class="product-list-link" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
-                      <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                        <img
-                          alt=""
-                          class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                          src="{{ matched_product.image | product_image_url | constrain: 20 }}"
-                          {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
-                          data-srcset="
-                            {{ matched_product.image | product_image_url | constrain: 240 }} 240w,
-                            {{ matched_product.image | product_image_url | constrain: 320 }} 320w,
-                            {{ matched_product.image | product_image_url | constrain: 400 }} 400w,
-                            {{ matched_product.image | product_image_url | constrain: 540 }} 540w,
-                            {{ matched_product.image | product_image_url | constrain: 600 }} 600w,
-                            {{ matched_product.image | product_image_url | constrain: 800 }} 800w,
-                            {{ matched_product.image | product_image_url | constrain: 960 }} 960w
-                          "
-                          data-sizes="auto"
-                        >
-                        {% if matched_product_status != blank %}<div class="product-list-thumb-status {{ matched_product_status_class }}">{{ matched_product_status }}</div>{% endif %}
-                      </div>
-                      <div class="product-list-thumb-info">
-                        <div class="product-list-thumb-name">{{ matched_product.name }}</div>
-                        <div class="product-list-thumb-price">
-                          {% unless matched_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                            {% if matched_product.variable_pricing %}
-                              {{ matched_product.min_price | money: theme.money_format }} - {{ matched_product.max_price | money: theme.money_format }}
-                            {% else %}
-                              {{ matched_product.default_price | money: theme.money_format }}
-                            {% endif %}
-                          {% endunless %}
-                        </div>
-                      </div>
-                    </a>
+  {% if theme.show_related_products %}
+    {% assign related_products_header = theme.related_products_header | default: 'You might also like' %}
+    {% assign related_products_collection = product.related_products %}  
+  
+    <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
+      <div class="related-products-header">
+        <h2 class="related-products-title">{{ related_products_header }}</h2>
+        <a class="related-products-view-all-link" href="/products">View all products</a>
+      </div>
+      <div class="product-list-container">
+        <div class="related-product-list product-list">
+          {% for related_product in related_products_collection %}
+            {% assign image_width = related_product.image.width | times: 1.0 %}
+            {% assign image_height = related_product.image.height | times: 1.0 %}
+            {% assign aspect_ratio = image_width | divided_by: image_height %}
+            {% assign related_product_status = '' %}
+            {% case related_product.status %}
+              {% when 'active' %}
+                {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %}
+              {% when 'sold-out' %}
+                {% assign related_product_status = 'Sold out' %}
+              {% when 'coming-soon' %}
+                {% assign related_product_status = 'Coming soon' %}
+            {% endcase %}
+            {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+            {% capture image_class %}
+              {% if related_product.image.height > related_product.image.width %}
+                image-tall
+              {% elsif related_product.image.height < related_product.image.width %}
+                image-wide
+              {% else %}
+                image-square
+              {% endif %}
+            {% endcapture %}
+            <div class="product-list-thumb {{ related_product.css_class }}">
+              <a class="product-list-link" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+                <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                  <img
+                    alt=""
+                    class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                    src="{{ related_product.image | product_image_url | constrain: 20 }}"
+                    {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
+                    data-srcset="
+                      {{ related_product.image | product_image_url | constrain: 240 }} 240w,
+                      {{ related_product.image | product_image_url | constrain: 320 }} 320w,
+                      {{ related_product.image | product_image_url | constrain: 400 }} 400w,
+                      {{ related_product.image | product_image_url | constrain: 540 }} 540w,
+                      {{ related_product.image | product_image_url | constrain: 600 }} 600w,
+                      {{ related_product.image | product_image_url | constrain: 800 }} 800w,
+                      {{ related_product.image | product_image_url | constrain: 960 }} 960w
+                    "
+                    data-sizes="auto"
+                  >
+                  {% if related_product_status != blank %}<div class="product-list-thumb-status {{ related_product_status_class }}">{{ related_product_status }}</div>{% endif %}
+                </div>
+                <div class="product-list-thumb-info">
+                  <div class="product-list-thumb-name">{{ related_product.name }}</div>
+                  <div class="product-list-thumb-price">
+                    {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% if related_product.variable_pricing %}
+                        {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
+                      {% else %}
+                        {{ related_product.default_price | money: theme.money_format }}
+                      {% endif %}
+                    {% endunless %}
                   </div>
-                {% endif %}
-              {% endfor %}
+                </div>
+              </a>
             </div>
-          </div>
-        </aside>
-      {% endif %}
-    {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+    </aside>
   {% endif %}
 </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -613,13 +613,25 @@
       "variable": "spotify_url",
       "label": "Spotify URL",
       "type": "text",
-      "description": "Ex: https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt"
+      "description": "Ex: https://open.spotify.com/artist/0gxy..."
     },
     {
       "variable": "linkedin_url",
       "label": "LinkedIn URL",
       "type": "text",
       "description": "Ex: https://linkedin.com/in/bigcartel"
+    },
+    {
+      "variable": "twitch_url",
+      "label": "Twitch URL",
+      "type": "text",
+      "description": "Ex: https://twitch.tv/username"
+    },
+    {
+      "variable": "twitch_url",
+      "label": "Twitch URL",
+      "type": "text",
+      "description": "Ex: https://twitch.tv/username"
     },
     {
       "variable": "tumblr_url",

--- a/source/settings.json
+++ b/source/settings.json
@@ -590,6 +590,34 @@
       ]
     },
     {
+      "variable": "show_categories_in_footer",
+      "label": "Show categories in footer",
+      "type": "boolean",
+      "default": true,
+      "description": "Show categories in the footer"
+    },
+    {
+      "variable": "footer_text",
+      "label": "Footer text",
+      "type": "text",
+      "max_length": 2048,
+      "description": "Show a custom message to your shop's footer"
+    },
+    {
+      "variable": "footer_text_position",
+      "label": "Footer text position",
+      "type": "select",
+      "options": [
+        ["Start of footer", "start"],
+        ["End of footer", "end"]
+      ],
+      "default": "end",
+      "description": "Choose where to show your footer message",
+      "requires": [
+        "footer_text present"
+      ]
+    },
+    {
       "variable": "money_format",
       "label": "Price display",
       "type": "select",

--- a/source/settings.json
+++ b/source/settings.json
@@ -418,6 +418,45 @@
       "description": "Pattern style for the accent background"
     },
     {
+      "variable": "show_related_products",
+      "label": "Show related products",
+      "type": "boolean",
+      "default": true,
+      "description": "Displays related products on the Product page"
+    },
+    {
+      "variable": "related_products_header",
+      "label": "Related products header",
+      "type": "text",
+      "description": "Displays above related products on Products pages",
+      "default": "You might also like",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "related_items",
+      "label": "Related products",
+      "type": "select",
+      "options": "1..8",
+      "default": 3,
+      "description": "The maximum number of related products to show on Product pages",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "related_products_order",
+      "label": "Related products order",
+      "type": "select",
+      "options": "product_orders",
+      "default": "sales",
+      "description": "The order of related products on the Product pages",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
       "variable": "show_search",
       "label": "Show search",
       "type": "boolean",

--- a/source/settings.json
+++ b/source/settings.json
@@ -437,7 +437,7 @@
       ]
     },
     {
-      "variable": "related_items",
+      "variable": "related_products",
       "label": "Related products",
       "type": "select",
       "options": "1..8",

--- a/source/settings.json
+++ b/source/settings.json
@@ -56,122 +56,151 @@
           {
             "style_name": "Classic #2",
             "fonts": {
-              "primary_font": "Chivo",
-              "secondary_font": "Chivo"
+              "primary_font": "PT Serif",
+              "secondary_font": "Source Sans Pro"
             },
             "colors": {
-              "background_color": "#141415",
-              "content_background_color": "#141415",
-              "accent_background_color": "#141415",
-              "accent_text_color": "#F8F8F8",
-              "accent_pattern_color": "#4A4A4E",
-              "header_text_color": "#F8F8F8",
-              "primary_text_color": "#F8F8F8",
-              "secondary_text_color": "#F8F8F8",
-              "button_text_color": "#141415",
-              "button_background_color": "#F8F8F8",
-              "button_hover_background_color": "#C6C6C6",
-              "badge_text_color_primary": "#222222",
-              "badge_background_color_primary": "#FFC65C",
-              "badge_text_color_secondary": "#222222",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#FFC65C",
-              "link_text_color": "#F8F8F8",
-              "link_hover_color": "#AEAEAE",
-              "announcement_text_color": "#141415",
-              "announcement_background_color": "#F8F8F8"
+              "background_color": "#1F2937",
+              "content_background_color": "#293548",
+              "accent_background_color": "#1F2937",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#3D4B5F",
+              "header_text_color": "#FFFFFF",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#B4C2D3",
+              "button_text_color": "#1F2937",
+              "button_background_color": "#93B5E5",
+              "button_hover_background_color": "#7A9FD3",
+              "badge_text_color_primary": "#1F2937",
+              "badge_background_color_primary": "#93B5E5",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#3D4B5F",
+              "inventory_status_text_color": "#93B5E5",
+              "link_text_color": "#FFFFFF",
+              "link_hover_color": "#93B5E5",
+              "announcement_text_color": "#1F2937",
+              "announcement_background_color": "#93B5E5"
             }
           },
           {
             "style_name": "Classic #3",
             "fonts": {
-              "primary_font": "Cabin",
-              "secondary_font": "Cabin"
+              "primary_font": "Libre Baskerville",
+              "secondary_font": "Work Sans"
             },
             "colors": {
-              "background_color": "#F8F8FA",
-              "content_background_color": "#FCFCFC",
-              "accent_background_color": "#F8F8FA",
-              "accent_text_color": "#2A2A2C",
-              "accent_pattern_color": "#E3E4EA",
-              "header_text_color": "#2A2A2C",
-              "primary_text_color": "#2A2A2C",
-              "secondary_text_color": "#2A2A2C",
+              "background_color": "#F8F9FA",
+              "content_background_color": "#FFFFFF",
+              "accent_background_color": "#1B4965",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#E2E8F0",
+              "header_text_color": "#1B4965",
+              "primary_text_color": "#1B4965",
+              "secondary_text_color": "#5C7A8C",
               "button_text_color": "#FFFFFF",
-              "button_background_color": "#2A2A2C",
-              "button_hover_background_color": "#3E3E40",
+              "button_background_color": "#487A9B",
+              "button_hover_background_color": "#386480",
               "badge_text_color_primary": "#FFFFFF",
-              "badge_background_color_primary": "#203BE1",
-              "badge_text_color_secondary": "#222222",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#203BE1",
-              "link_text_color": "#2A2A2C",
-              "link_hover_color": "#203BE1",
-              "announcement_text_color": "#2A2A2C",
-              "announcement_background_color": "#E3E4EA"
+              "badge_background_color_primary": "#D95030",
+              "badge_text_color_secondary": "#1B4965",
+              "badge_background_color_secondary": "#E2E8F0",
+              "inventory_status_text_color": "#D95030",
+              "link_text_color": "#1B4965",
+              "link_hover_color": "#487A9B",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#487A9B"
             }
           }
         ]
       },
       {
-        "group_name": "Natural",
+        "group_name": "Bold",
         "styles": [
           {
-            "style_name": "Natural #1",
+            "style_name": "Bold #1",
             "fonts": {
-              "primary_font": "Lato",
-              "secondary_font": "Lato"
+              "primary_font": "Inknut Antiqua",
+              "secondary_font": "Source Sans Pro"
             },
             "colors": {
-              "background_color": "#F5F4EE",
-              "content_background_color": "#FDFDF8",
-              "accent_background_color": "#F5F4EE",
-              "accent_text_color": "#262522",
-              "accent_pattern_color": "#C3BE98",
-              "header_text_color": "#262522",
-              "primary_text_color": "#262522",
-              "secondary_text_color": "#8A4942",
-              "button_text_color": "#F5F4EE",
-              "button_background_color": "#8A4942",
-              "button_hover_background_color": "#A76561",
-              "badge_text_color_primary": "#FFFFFF",
-              "badge_background_color_primary": "#9A9A32",
-              "badge_text_color_secondary": "#262522",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#9A9A32",
-              "link_text_color": "#262522",
-              "link_hover_color": "#8A4942",
-              "announcement_text_color": "#262522",
-              "announcement_background_color": "#F1DBCE"
+              "background_color": "#5F0F40",
+              "content_background_color": "#741352",
+              "accent_background_color": "#5F0F40",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#8B1E60",
+              "header_text_color": "#FFFFFF",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#FFB8D9",
+              "button_text_color": "#5F0F40",
+              "button_background_color": "#00F5D4",
+              "button_hover_background_color": "#00D6B9",
+              "badge_text_color_primary": "#5F0F40",
+              "badge_background_color_primary": "#00F5D4",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#8B1E60",
+              "inventory_status_text_color": "#00F5D4",
+              "link_text_color": "#FFFFFF",
+              "link_hover_color": "#00F5D4",
+              "announcement_text_color": "#5F0F40",
+              "announcement_background_color": "#00F5D4"
             }
           },
           {
-            "style_name": "Natural #2",
+            "style_name": "Bold #2",
             "fonts": {
-              "primary_font": "Cutive Mono",
-              "secondary_font": "Cutive Mono"
+              "primary_font": "Chivo",
+              "secondary_font": "Sora"
             },
             "colors": {
-              "background_color": "#FEF5EF",
-              "content_background_color": "#FFFDFC",
-              "accent_background_color": "#FEF5EF",
-              "accent_text_color": "#584B53",
-              "accent_pattern_color": "#E4BB97",
-              "header_text_color": "#584B53",
-              "primary_text_color": "#584B53",
-              "secondary_text_color": "#584B53",
-              "button_text_color": "#FFFDFC",
-              "button_background_color": "#584B53",
-              "button_hover_background_color": "#74686C",
+              "background_color": "#F7B538",
+              "content_background_color": "#E5A932",
+              "accent_background_color": "#F7B538",
+              "accent_text_color": "#000000",
+              "accent_pattern_color": "#FFE0A1",
+              "header_text_color": "#000000",
+              "primary_text_color": "#000000",
+              "secondary_text_color": "#734800",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#DB2763",
+              "button_hover_background_color": "#C11E54",
               "badge_text_color_primary": "#FFFFFF",
-              "badge_background_color_primary": "#9D5C63",
-              "badge_text_color_secondary": "#262522",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#9D5C63",
-              "link_text_color": "#584B53",
-              "link_hover_color": "#9D5C63",
-              "announcement_text_color": "#584B53",
-              "announcement_background_color": "#D6E3F8"
+              "badge_background_color_primary": "#DB2763",
+              "badge_text_color_secondary": "#000000",
+              "badge_background_color_secondary": "#F9C55F",
+              "inventory_status_text_color": "#DB2763",
+              "link_text_color": "#000000",
+              "link_hover_color": "#DB2763",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#DB2763"
+            }
+          },
+          {
+            "style_name": "Bold #3",
+            "fonts": {
+              "primary_font": "Signika",
+              "secondary_font": "Signika"
+            },
+            "colors": {
+              "background_color": "#080808",
+              "content_background_color": "#141414",
+              "accent_background_color": "#080808",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#2B2B2B",
+              "header_text_color": "#FFFFFF",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#999999",
+              "button_text_color": "#000000",
+              "button_background_color": "#3DEC00",
+              "button_hover_background_color": "#35C900",
+              "badge_text_color_primary": "#000000",
+              "badge_background_color_primary": "#3DEC00",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#2B2B2B",
+              "inventory_status_text_color": "#3DEC00",
+              "link_text_color": "#FFFFFF",
+              "link_hover_color": "#3DEC00",
+              "announcement_text_color": "#000000",
+              "announcement_background_color": "#3DEC00"
             }
           }
         ]
@@ -182,88 +211,272 @@
           {
             "style_name": "Playful #1",
             "fonts": {
-              "primary_font": "Arvo",
-              "secondary_font": "Courier New"
+              "primary_font": "Quicksand",
+              "secondary_font": "BioRhyme"
             },
             "colors": {
-              "background_color": "#E2E8CE",
-              "content_background_color": "#F6F7F2",
-              "accent_background_color": "#E2E8CE",
-              "accent_text_color": "#262626",
-              "accent_pattern_color": "#ACBFA4",
-              "header_text_color": "#262626",
-              "primary_text_color": "#262626",
-              "secondary_text_color": "#262626",
-              "button_text_color": "#F6F7F2",
-              "button_background_color": "#F35900",
-              "button_hover_background_color": "#FF814D",
-              "badge_text_color_primary": "#EFEFEF",
-              "badge_background_color_primary": "#F35900",
-              "badge_text_color_secondary": "#262626",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#F35900",
-              "link_text_color": "#262626",
-              "link_hover_color": "#F35900",
-              "announcement_text_color": "#F6F7F2",
-              "announcement_background_color": "#F35900"
+              "background_color": "#FF7171",
+              "content_background_color": "#FF8989",
+              "accent_background_color": "#FF7171",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#FFD6D6",
+              "header_text_color": "#FFFFFF",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#FFD6D6",
+              "button_text_color": "#FF7171",
+              "button_background_color": "#4ECDC4",
+              "button_hover_background_color": "#44B5AE",
+              "badge_text_color_primary": "#FF7171",
+              "badge_background_color_primary": "#4ECDC4",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#FFA1A1",
+              "inventory_status_text_color": "#4ECDC4",
+              "link_text_color": "#FFFFFF",
+              "link_hover_color": "#4ECDC4",
+              "announcement_text_color": "#FF7171",
+              "announcement_background_color": "#4ECDC4"
             }
           },
           {
             "style_name": "Playful #2",
             "fonts": {
-              "primary_font": "Syne",
-              "secondary_font": "Inter"
+              "primary_font": "Overlock",
+              "secondary_font": "Karla"
             },
             "colors": {
-              "background_color": "#FFFFFF",
-              "content_background_color": "#FFFFFF",
-              "accent_background_color": "#FFF795",
-              "accent_text_color": "#0000FF",
-              "accent_pattern_color": "#FFFFFF",
-              "header_text_color": "#0000FF",
-              "primary_text_color": "#0000FF",
-              "secondary_text_color": "#0000FF",
-              "button_text_color": "#FFFFFF",
-              "button_background_color": "#0000FF",
-              "button_hover_background_color": "#3333FF",
-              "badge_text_color_primary": "#0000FF",
-              "badge_background_color_primary": "#FFD700",
-              "badge_text_color_secondary": "#262626",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#0000FF",
-              "link_text_color": "#0000FF",
-              "link_hover_color": "#0000FF",
-              "announcement_text_color": "#FFFFFF",
-              "announcement_background_color": "#0000FF"
+              "background_color": "#00C1B5",
+              "content_background_color": "#00D5C8",
+              "accent_background_color": "#00C1B5",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#7CEEE7",
+              "header_text_color": "#FFFFFF",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#B3FFF9",
+              "button_text_color": "#00C1B5",
+              "button_background_color": "#FFE66D",
+              "button_hover_background_color": "#FFE147",
+              "badge_text_color_primary": "#00C1B5",
+              "badge_background_color_primary": "#FFE66D",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#26D6CC",
+              "inventory_status_text_color": "#FFE66D",
+              "link_text_color": "#FFFFFF",
+              "link_hover_color": "#FFE66D",
+              "announcement_text_color": "#00C1B5",
+              "announcement_background_color": "#FFE66D"
             }
           },
           {
             "style_name": "Playful #3",
             "fonts": {
-              "primary_font": "Quicksand",
+              "primary_font": "Chewy",
+              "secondary_font": "DM Sans"
+            },
+            "colors": {
+              "background_color": "#6B4CF5",
+              "content_background_color": "#7B61F7",
+              "accent_background_color": "#6B4CF5",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#CFC4FF",
+              "header_text_color": "#FFFFFF",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#E0D6FF",
+              "button_text_color": "#6B4CF5",
+              "button_background_color": "#FFB2E6",
+              "button_hover_background_color": "#FF99DD",
+              "badge_text_color_primary": "#6B4CF5",
+              "badge_background_color_primary": "#FFB2E6",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#8B75F8",
+              "inventory_status_text_color": "#FFB2E6",
+              "link_text_color": "#FFFFFF",
+              "link_hover_color": "#FFB2E6",
+              "announcement_text_color": "#6B4CF5",
+              "announcement_background_color": "#FFB2E6"
+            }
+          }
+        ]
+      },
+      {
+        "group_name": "Earthy",
+        "styles": [
+          {
+            "style_name": "Earthy #1",
+            "fonts": {
+              "primary_font": "Rokkitt",
+              "secondary_font": "Source Sans Pro"
+            },
+            "colors": {
+              "background_color": "#E3D5CA",
+              "content_background_color": "#EDDED5",
+              "accent_background_color": "#967259",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#D4BFB2",
+              "header_text_color": "#553A2D",
+              "primary_text_color": "#553A2D",
+              "secondary_text_color": "#7D604E",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#967259",
+              "button_hover_background_color": "#876349",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#D35F29",
+              "badge_text_color_secondary": "#553A2D",
+              "badge_background_color_secondary": "#D4BFB2",
+              "inventory_status_text_color": "#D35F29",
+              "link_text_color": "#553A2D",
+              "link_hover_color": "#D35F29",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#967259"
+            }
+          },
+          {
+            "style_name": "Earthy #2",
+            "fonts": {
+              "primary_font": "Enriqueta",
+              "secondary_font": "Enriqueta"
+            },
+            "colors": {
+              "background_color": "#4A6741",
+              "content_background_color": "#557A4B",
+              "accent_background_color": "#4A6741",
+              "accent_text_color": "#F4ECD3",
+              "accent_pattern_color": "#5F8353",
+              "header_text_color": "#F4ECD3",
+              "primary_text_color": "#F4ECD3",
+              "secondary_text_color": "#C5DBC0",
+              "button_text_color": "#4A6741",
+              "button_background_color": "#E7B355",
+              "button_hover_background_color": "#D9A13D",
+              "badge_text_color_primary": "#4A6741",
+              "badge_background_color_primary": "#E7B355",
+              "badge_text_color_secondary": "#F4ECD3",
+              "badge_background_color_secondary": "#5F8353",
+              "inventory_status_text_color": "#E7B355",
+              "link_text_color": "#F4ECD3",
+              "link_hover_color": "#E7B355",
+              "announcement_text_color": "#4A6741",
+              "announcement_background_color": "#E7B355"
+            }
+          },
+          {
+            "style_name": "Earthy #3",
+            "fonts": {
+              "primary_font": "Andada Pro",
+              "secondary_font": "Work Sans"
+            },
+            "colors": {
+              "background_color": "#D7BBA8",
+              "content_background_color": "#E4CFC1",
+              "accent_background_color": "#A15429",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#C4A08E",
+              "header_text_color": "#422112",
+              "primary_text_color": "#422112",
+              "secondary_text_color": "#744F3A",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#A15429",
+              "button_hover_background_color": "#8B4823",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#744F3A",
+              "badge_text_color_secondary": "#422112",
+              "badge_background_color_secondary": "#C4A08E",
+              "inventory_status_text_color": "#A15429",
+              "link_text_color": "#422112",
+              "link_hover_color": "#A15429",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#A15429"
+            }
+          }
+        ]
+      },
+      {
+        "group_name": "Dreamy",
+        "styles": [
+          {
+            "style_name": "Dreamy #1",
+            "fonts": {
+              "primary_font": "Cormorant",
               "secondary_font": "Quicksand"
             },
             "colors": {
-              "background_color": "#FFE9F4",
-              "content_background_color": "#FFFBFD",
-              "accent_background_color": "#FFB4D9",
-              "accent_text_color": "#243588",
-              "accent_pattern_color": "#FFE9F4",
-              "header_text_color": "#243588",
-              "primary_text_color": "#243588",
-              "secondary_text_color": "#243588",
-              "button_text_color": "#243588",
-              "button_background_color": "#ECD8FF",
-              "button_hover_background_color": "#F4E6FF",
-              "badge_text_color_primary": "#243588",
-              "badge_background_color_primary": "#FFB4D9",
-              "badge_text_color_secondary": "#262626",
-              "badge_background_color_secondary": "#B7B7B7",
-              "inventory_status_text_color": "#243588",
-              "link_text_color": "#243588",
-              "link_hover_color": "#F6248C",
-              "announcement_text_color": "#243588",
-              "announcement_background_color": "#FFFA8D"
+              "background_color": "#E0F4FF",
+              "content_background_color": "#ECF8FF",
+              "accent_background_color": "#7EB2DD",
+              "accent_text_color": "#1A4971",
+              "accent_pattern_color": "#C5E4FF",
+              "header_text_color": "#1A4971",
+              "primary_text_color": "#1A4971",
+              "secondary_text_color": "#4A789B",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#7EB2DD",
+              "button_hover_background_color": "#619AC9",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#FF9EAA",
+              "badge_text_color_secondary": "#1A4971",
+              "badge_background_color_secondary": "#C5E4FF",
+              "inventory_status_text_color": "#FF9EAA",
+              "link_text_color": "#1A4971",
+              "link_hover_color": "#7EB2DD",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#7EB2DD"
+            }
+          },
+          {
+            "style_name": "Dreamy #2",
+            "fonts": {
+              "primary_font": "Spectral",
+              "secondary_font": "Quicksand"
+            },
+            "colors": {
+              "background_color": "#F5EBF7",
+              "content_background_color": "#F9F2FB",
+              "accent_background_color": "#B893B2",
+              "accent_text_color": "#805B7B",
+              "accent_pattern_color": "#E8D6E5",
+              "header_text_color": "#805B7B",
+              "primary_text_color": "#805B7B",
+              "secondary_text_color": "#A68BA2",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#B893B2",
+              "button_hover_background_color": "#9B7994",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#C9A4C4",
+              "badge_text_color_secondary": "#805B7B",
+              "badge_background_color_secondary": "#E8D6E5",
+              "inventory_status_text_color": "#C9A4C4",
+              "link_text_color": "#805B7B",
+              "link_hover_color": "#B893B2",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#B893B2"
+            }
+          },
+          {
+            "style_name": "Dreamy #3",
+            "fonts": {
+              "primary_font": "Fraunces",
+              "secondary_font": "DM Sans"
+            },
+            "colors": {
+              "background_color": "#F9F2FF",
+              "content_background_color": "#FDF9FF",
+              "accent_background_color": "#9C89B8",
+              "accent_text_color": "#FFFFFF",
+              "accent_pattern_color": "#E8DDFF",
+              "header_text_color": "#4A3B5E",
+              "primary_text_color": "#4A3B5E",
+              "secondary_text_color": "#786A8E",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#9C89B8",
+              "button_hover_background_color": "#8A75A8",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#F0A6CA",
+              "badge_text_color_secondary": "#4A3B5E",
+              "badge_background_color_secondary": "#E8DDFF",
+              "inventory_status_text_color": "#F0A6CA",
+              "link_text_color": "#4A3B5E",
+              "link_hover_color": "#9C89B8",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#9C89B8"
             }
           }
         ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranger",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -71,7 +71,7 @@
               "button_background_color": "#F8F8F8",
               "button_hover_background_color": "#C6C6C6",
               "badge_text_color_primary": "#222222",
-              "badge_background_color_primary": "#ffc65c",
+              "badge_background_color_primary": "#FFC65C",
               "badge_text_color_secondary": "#222222",
               "badge_background_color_secondary": "#B7B7B7",
               "link_text_color": "#F8F8F8",
@@ -132,7 +132,7 @@
               "button_background_color": "#8A4942",
               "button_hover_background_color": "#A76561",
               "badge_text_color_primary": "#FFFFFF",
-              "badge_background_color_primary": "#9a9a32",
+              "badge_background_color_primary": "#9A9A32",
               "badge_text_color_secondary": "#262522",
               "badge_background_color_secondary": "#B7B7B7",
               "link_text_color": "#262522",
@@ -547,7 +547,7 @@
     },
     {
       "variable": "desktop_product_page_images",
-      "label": "Desktop product page images",
+      "label": "Desktop Product page images",
       "type": "select",
       "options": [
         ["Thumbnails", "thumbnails"],
@@ -560,7 +560,7 @@
     },
     {
       "variable": "mobile_product_page_images",
-      "label": "Mobile product page image carousel",
+      "label": "Mobile Product page image carousel",
       "type": "select",
       "options": [
         ["Show thumbnails", "show-thumbnails"],

--- a/source/settings.json
+++ b/source/settings.json
@@ -46,6 +46,7 @@
               "badge_background_color_primary": "#C43F06",
               "badge_text_color_secondary": "#222222",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#C43F06",
               "link_text_color": "#222222",
               "link_hover_color": "#FF642A",
               "announcement_text_color": "#FFFFFF",
@@ -74,6 +75,7 @@
               "badge_background_color_primary": "#FFC65C",
               "badge_text_color_secondary": "#222222",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#FFC65C",
               "link_text_color": "#F8F8F8",
               "link_hover_color": "#AEAEAE",
               "announcement_text_color": "#141415",
@@ -102,6 +104,7 @@
               "badge_background_color_primary": "#203BE1",
               "badge_text_color_secondary": "#222222",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#203BE1",
               "link_text_color": "#2A2A2C",
               "link_hover_color": "#203BE1",
               "announcement_text_color": "#2A2A2C",
@@ -135,6 +138,7 @@
               "badge_background_color_primary": "#9A9A32",
               "badge_text_color_secondary": "#262522",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#9A9A32",
               "link_text_color": "#262522",
               "link_hover_color": "#8A4942",
               "announcement_text_color": "#262522",
@@ -163,6 +167,7 @@
               "badge_background_color_primary": "#9D5C63",
               "badge_text_color_secondary": "#262522",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#9D5C63",
               "link_text_color": "#584B53",
               "link_hover_color": "#9D5C63",
               "announcement_text_color": "#584B53",
@@ -196,6 +201,7 @@
               "badge_background_color_primary": "#F35900",
               "badge_text_color_secondary": "#262626",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#F35900",
               "link_text_color": "#262626",
               "link_hover_color": "#F35900",
               "announcement_text_color": "#F6F7F2",
@@ -224,6 +230,7 @@
               "badge_background_color_primary": "#FFD700",
               "badge_text_color_secondary": "#262626",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#0000FF",
               "link_text_color": "#0000FF",
               "link_hover_color": "#0000FF",
               "announcement_text_color": "#FFFFFF",
@@ -252,6 +259,7 @@
               "badge_background_color_primary": "#FFB4D9",
               "badge_text_color_secondary": "#262626",
               "badge_background_color_secondary": "#B7B7B7",
+              "inventory_status_text_color": "#243588",
               "link_text_color": "#243588",
               "link_hover_color": "#F6248C",
               "announcement_text_color": "#243588",
@@ -349,6 +357,11 @@
       "variable": "badge_background_color_secondary",
       "label": "Badge background (secondary)",
       "default": "#B7B7B7"
+    },
+    {
+      "variable": "inventory_status_text_color",
+      "label": "Low Inventory messages",
+      "default": "#E15C2A"
     },
     {
       "variable": "link_text_color",
@@ -568,6 +581,53 @@
       ],
       "default": "show-thumbnails",
       "description": "Choose to hide or show thumbnails on the mobile Product page carousel"
+    },
+    {
+      "variable": "show_low_inventory_messages",
+      "label": "Show product stock alerts",
+      "type": "boolean",
+      "default": true,
+      "description": "Show shoppers alerts on Product pages when it's running low on stock",
+      "requires": [
+        "inventory"
+      ]
+    },
+    {
+      "variable": "low_inventory_threshold",
+      "label": "Low stock alert",
+      "options": "1..100",
+      "type": "select",
+      "default": "10",
+      "description": "When stock drops below this number, shoppers will see low stock message. 'Almost sold out' message shows at half this amount",
+      "requires": [
+        "inventory",
+        "show_low_inventory_messages eq true"
+      ]
+    },
+    {
+      "variable": "low_inventory_message",
+      "label": "Low stock message",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below your alert level",
+      "default": "Limited quantities available",
+      "requires": [
+        "inventory",
+        "show_low_inventory_messages eq true"
+      ]
+    },
+    {
+      "variable": "almost_sold_out_message",
+      "label": "Almost sold out message",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below half your alert level",
+      "default": "Only a few left!",
+      "requires": [
+        "inventory",
+        "show_low_inventory_messages eq true",
+        "low_inventory_threshold gt 1"
+      ]
     },
     {
       "variable": "show_sold_out_product_options",

--- a/source/settings.json
+++ b/source/settings.json
@@ -362,12 +362,12 @@
     },
     {
       "variable": "announcement_text_color",
-      "label": "Announcement Message Text",
+      "label": "Announcement message text",
       "default": "#FFFFFF"
     },
     {
       "variable": "announcement_background_color",
-      "label": "Announcement Message Background",
+      "label": "Announcement message background",
       "default": "#000000"
     }
   ],
@@ -376,6 +376,7 @@
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
       "type": "text",
+      "max_length": 2048,
       "description": "A message visitors see when your shop is in Maintenance Mode",
       "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
@@ -383,6 +384,7 @@
       "variable": "announcement_message_text",
       "label": "Announcement text",
       "type": "text",
+      "max_length": 500,
       "description": "Displays an announcement message on the top of every page"
     },
     {
@@ -572,16 +574,20 @@
       "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
-      "description": "Shows sold out product variants in the Product page dropdowns",
-      "requires": "inventory"
+      "description": "Show sold out variants in product dropdowns. Best for shops that generally restock items; consider hiding if most sold out items won't return",
+      "requires": [
+        "inventory"
+      ]
     },
     {
       "variable": "show_sold_out_product_prices",
       "label": "Show prices for sold out products",
       "type": "boolean",
       "default": true,
-      "description": "Show the price of sold out products on product grids and product pages",
-      "requires": "inventory"
+      "description": "Show the price of sold out products on product grids and Product pages",
+      "requires": [
+        "inventory"
+      ]
     },
     {
       "variable": "money_format",

--- a/source/settings.json
+++ b/source/settings.json
@@ -610,6 +610,18 @@
       "description": "Ex: https://youtube.com/@BigCartelDotCom"
     },
     {
+      "variable": "spotify_url",
+      "label": "Spotify URL",
+      "type": "text",
+      "description": "Ex: https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt"
+    },
+    {
+      "variable": "linkedin_url",
+      "label": "LinkedIn URL",
+      "type": "text",
+      "description": "Ex: https://linkedin.com/in/bigcartel"
+    },
+    {
       "variable": "tumblr_url",
       "label": "Tumblr URL",
       "type": "text",

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -30,6 +30,8 @@
   --badge-text-color-secondary: #{"{{ theme.badge_text_color_secondary }}"}
   --badge-background-color-secondary: #{"{{ theme.badge_background_color_secondary }}"}
 
+  --inventory-status-text-color: #{"{{ theme.inventory_status_text_color }}"}
+
   --link-text-color: #{"{{ theme.link_text_color }}"}
   --link-hover-color: #{"{{ theme.link_hover_color }}"}
 

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -285,30 +285,56 @@ footer
     align-items: flex-start
     justify-content: flex-start
     flex-wrap: wrap
+    padding-bottom: 60px
 
     @media screen and (max-width: $break-large)
-      padding: 0 32px
+      padding: 0 32px 50px 32px
 
     @media screen and (max-width: $break-small)
       flex-direction: column
-      padding: 0 16px
+      padding-bottom: 30px
 
   .credit-container
     margin-left: auto
 
     @media screen and (max-width: $break-medium)
-      margin: 0
+      margin: 0 auto
+      width: 100%
+      text-align: center
+    
+    @media screen and (max-width: $break-small)
+      margin-left: 16px
+      width: auto
+      text-align: left
+
+    &--primary
+      @media screen and (max-width: $break-medium)
+        display: none
+
+    &--secondary
+      display: none
+
+      @media screen and (max-width: $break-medium)
+        display: block
+
 
     .bigcartel-credit
       line-height: 1em
-      font-size: 15px
+      font-size: 13px
       display: flex
       color: var(--accent-text-color)
-      align-items: center
+      flex-direction: column
       gap: 8px
       outline-offset: 4px
       padding: 2px 0
       text-decoration: none
+
+      @media screen and (max-width: $break-medium)
+        font-size: 15px
+        flex-direction: row
+        align-items: center
+        justify-content: center
+        width: 100%
 
       &__text
         position: relative
@@ -318,6 +344,10 @@ footer
         fill: currentColor
         padding-top: 1px
         width: 86px
+
+.footer-custom-content
+  text-align: center
+  padding: 10px 16px 40px 16px
 
 .footernav
   display: flex

--- a/source/stylesheets/maintenance.sass
+++ b/source/stylesheets/maintenance.sass
@@ -14,7 +14,7 @@
     background: var(--content-background-color)
     color: var(--primary-text-color)
     margin: 0 auto
-    max-width: 600px
+    max-width: 720px
     padding: 24px 48px 40px
     text-align: center
     width: 100%
@@ -29,3 +29,9 @@
       margin: 0 0 16px 0
       height: auto
       padding: 0
+
+    .maintenance-message *
+      text-align: inherit
+    
+    .social-icons
+      margin: 16px 0 0 0

--- a/source/stylesheets/navigation.sass
+++ b/source/stylesheets/navigation.sass
@@ -341,6 +341,18 @@ header
     li a
       padding: 4px 0
       font-size: 1.1em
+  
+  &__custom-pages
+    position: relative
+    
+    &::before
+      content: ''
+      position: absolute
+      left: 16px
+      top: -15px
+      width: 30px
+      height: 1px
+      background-color: var(--border-color)
 
   &__icons
     column-gap: 36px

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -146,3 +146,11 @@ section.content
 
 #instant-checkout-button
   margin-top: 12px
+
+.inventory-status-message
+  color: var(--inventory-status-text-color)
+  font-size: 0.9em
+  margin: 10px 0 auto
+  text-align: center
+  padding: 8px 0
+  font-weight: 500

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -128,5 +128,21 @@ section.content
     margin: 0
     text-align: left
 
+.related-products-container
+  margin-top: 100px
+
+.related-products-header
+  display: flex
+  align-items: center
+  margin-bottom: 24px
+
+  .related-products-view-all-link
+    margin-left: auto
+    font-weight: 500
+
+    &:hover
+      text-decoration: underline
+      text-underline-offset: 3px
+
 #instant-checkout-button
   margin-top: 12px


### PR DESCRIPTION
- feat: redesigned related products to use collection off product drop. 
- feat: new settings to control related products: header, number of products and sort order
- feat: redesigned style presets into 5 new categories with new styles
- feat: limited quantity messaging on product pages, behavior controlled by new settings
- feat: custom footer text support
- fix: contact page name use configured name vs hardcoding
- chore: styling tweaks on footer
- chore: header now conditioanlly shows contact based on the `nav_items` setting as it's lower priority
- chore: homepage slideshow now autoplays by default
- chore: remove "Back to site" from global nav
- chore: maintenance mode page tweaks for margin and padding
- chore: renamed setting `related_items` to `related_products`