### PR TITLE
v2.6.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -66,7 +66,18 @@
               </div>
               <div class="cart-submit">
                 <button type="submit" name="checkout" class="button button--checkout">Checkout</button>
-                <a class="button minimal-button" href="/products">Continue Shopping</a>
+                {% if theme.show_bnpl_messaging and cart.items != blank %}
+                  {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
+                    <div id="payment-processor-messaging">
+                      <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+                        <div id="paypal-messaging-element"></div>
+                      </div>
+                      <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+                        <div id="payment-method-messaging-element"></div>
+                      </div>
+                    </div>
+                  {% endunless %}
+                {% endif %}
                 {% if cart.shareable_link %}
                   <a href="{{ cart.shareable_link }}" class="button minimal-button copy-cart-link" data-clipboard-text="{{ cart.shareable_link }}">Share this cart</a>
                 {% endif %}

--- a/source/home.html
+++ b/source/home.html
@@ -6,7 +6,7 @@
   </ul>
 {% endif %}
 
-<div class="page-content home-page{% if theme.welcome_header != blank or theme.welcome_subheader != blank or theme.welcome_image != blank or theme.image_sets.slideshow.size == 0 %} has-welcome{% endif %}">
+<div class="page-content home-page{% if theme.welcome_header != blank or theme.welcome_subheader != blank or theme.welcome_image != blank %} has-welcome{% endif %}">
 
   {% if theme.image_sets.slideshow.size > 0 %}
     <div class="{% if theme.image_sets.slideshow.size > 1 %}splide{% endif %} home-slideshow">

--- a/source/home.html
+++ b/source/home.html
@@ -6,7 +6,26 @@
   </ul>
 {% endif %}
 
-<div class="page-content home-page{% if theme.welcome_header != blank or theme.welcome_subheader != blank or theme.welcome_image != blank %} has-welcome{% endif %}">
+<div class="page-content home-page{% if theme.welcome_header != blank or theme.welcome_subheader != blank or theme.welcome_image != blank or theme.image_sets.slideshow.size == 0 %} has-welcome{% endif %}">
+
+  {% if theme.image_sets.slideshow.size > 0 %}
+    <div class="{% if theme.image_sets.slideshow.size > 1 %}splide{% endif %} home-slideshow">
+      <div class="splide__track">
+        <div class="splide__list">
+          {% for image in theme.image_sets.slideshow %}
+            <div class="splide__slide">
+              <img
+                alt="Slideshow image {{ forloop.index }}"
+                {% if forloop.index == 1 %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
+                class="slideshow-image"
+                srcset="{{ image.url | constrain: 1068 }}, {{ image.url | constrain: 2136 }} 2x"
+                src="{{ image.url | constrain: 1068 }}">
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
   {% if theme.featured_header != blank and theme.featured_items > 0 %}
     <h1 class="featured-title">{{ theme.featured_header }}</h1>
   {% endif %}

--- a/source/home.html
+++ b/source/home.html
@@ -6,8 +6,10 @@
   </ul>
 {% endif %}
 
-<h1 class="visually-hidden">Featured {{ theme.featured_items_type }}</h1>
 <div class="page-content home-page{% if theme.welcome_header != blank or theme.welcome_subheader != blank or theme.welcome_image != blank %} has-welcome{% endif %}">
+  {% if theme.featured_header != blank and theme.featured_items > 0 %}
+    <h1 class="featured-title">{{ theme.featured_header }}</h1>
+  {% endif %}
   {% if theme.featured_items_type == 'Categories' %}
     {% if categories.active != blank and theme.featured_items > 0 %}
       <div class="product-list category-list {% if categories.active.size < 4 %} justify-center{% endif %}">

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -144,6 +144,7 @@ updateCartCounts = (cart) => {
 
   if (cartSubtotal) { htmlHighlight(cartSubtotal, sub_total); }
 
+  showBnplMessaging(cart.total, { alignment: 'center', displayMode: 'flex', pageType: 'cart' });
 }
 
 processUpdate = (input, item_id, new_val, cart) => {
@@ -174,3 +175,14 @@ processUpdate = (input, item_id, new_val, cart) => {
     document.querySelector('.cart-item[data-item-id="'+item_id+'"]').remove();
   }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const isCartPage = document.body.getAttribute('data-bc-page-type') === 'cart';
+  if (isCartPage) {
+    Cart.refresh((cart) => {
+      if (cart?.total) {
+        showBnplMessaging(cart.total, { alignment: 'center', displayMode: 'flex', pageType: 'cart' });
+      }
+    });
+  }
+});

--- a/source/javascripts/home-carousel.js
+++ b/source/javascripts/home-carousel.js
@@ -1,7 +1,7 @@
-const homeSlideshowContainer = document.querySelector('.home-slideshow');
+const homeSlideshowContainer = document.querySelector('.splide.home-slideshow');
 if (homeSlideshowContainer) {
   document.addEventListener( 'DOMContentLoaded', function() {
-    var splide = new Splide( '.home-slideshow', {
+    var splide = new Splide( '.splide.home-slideshow', {
       arrows: false,
       type: 'slide',
       autoplay: themeOptions.homepageSlideshowAutoplay,

--- a/source/javascripts/home-carousel.js
+++ b/source/javascripts/home-carousel.js
@@ -1,0 +1,15 @@
+const homeSlideshowContainer = document.querySelector('.home-slideshow');
+if (homeSlideshowContainer) {
+  document.addEventListener( 'DOMContentLoaded', function() {
+    var splide = new Splide( '.home-slideshow', {
+      arrows: false,
+      type: 'slide',
+      autoplay: themeOptions.homepageSlideshowAutoplay,
+      interval: themeOptions.homepageSlideshowSpeed,
+      speed: 1500,
+      rewind: true,
+      keyboard: true,
+    } );
+    splide.mount();
+  });
+}

--- a/source/javascripts/product-payment-messaging.js
+++ b/source/javascripts/product-payment-messaging.js
@@ -1,0 +1,655 @@
+/**
+ * BNPL Payment Messaging Module
+ * 
+ * Handles detection and display of Buy Now Pay Later messaging for Stripe and PayPal 
+ * on Product and Cart pages
+ * 
+ * Key functionality:
+ * - Renders appropriate messaging based on product price
+ * - Custom visibility detection logic for Stripe since it lacks a built-in method
+ * - Adapts styling to match shop theme for Stripe, but only when Paypal isn't shown due to 
+ *   their limitations
+ * - Updates messaging when price changes
+ * 
+ * Usage:
+ * // On product page:
+ * showBnplMessaging(product.price, { alignment: 'left', pageType: 'product' });
+ * 
+ * // On cart page:
+ * showBnplMessaging(cart.total, { alignment: 'center', displayMode: 'flex', pageType: 'cart' });
+ *  
+ */
+
+/**
+ * Configuration settings
+ */
+const PAYMENT_CONFIG = {
+  SUPPORTED_PROCESSORS: {
+    stripe: {
+      elementId: 'payment-method-messaging-element',
+      containerId: 'stripe-messaging-container',
+      paymentMethodTypes: ['klarna', 'afterpay_clearpay', 'affirm'],
+      heightThresholds: {
+        minVisibleHeight: 16
+      },
+      timeouts: {
+        initialization: 1000,
+        heightCheck: 300
+      },
+      detection: {
+        maxWaitTime: 5000,
+        pollInterval: 100,
+        minRetries: 3
+      }
+    },
+    paypal: {
+      elementId: 'paypal-messaging-element',
+      containerId: 'paypal-messaging-container',
+      timeouts: {
+        render: 500
+      },
+      pageTypes: {
+        product: 'product-details',
+        cart: 'cart',
+        default: 'product-details'
+      }
+    }
+  },
+  DEFAULT_COLORS: {
+    background: '#FFFFFF',
+    text: '#000000'
+  },
+  DEFAULT_ALIGNMENT: 'left',
+  PARENT_CONTAINER: {
+    containerId: 'payment-processor-messaging',
+    defaultDisplayMode: 'block'
+  }
+};
+
+/**
+ * Helper functions
+ */
+
+/**
+ * Validates and normalizes a price value
+ * @param {number|string} price - Price to validate
+ * @returns {number|null} Validated price or null if invalid
+ */
+function validatePrice(price) {
+  const isValidNumber = (val) => typeof val === 'number' && val > 0 && !isNaN(val);
+  const numericPrice = Number(price);
+  
+  if (isValidNumber(numericPrice)) return numericPrice;
+  
+  const defaultPrice = window.bigcartel?.product?.default_price;
+  return isValidNumber(defaultPrice) ? defaultPrice : null;
+}
+
+/**
+ * Calculates relative luminance from a hex color
+ * Uses the formula from WCAG 2.0
+ * @param {string} bgColor - Background color hex
+ * @returns {number} Luminance value (0-1)
+ */
+function calculateLuminance(bgColor) {
+  const hex = bgColor.replace('#', '');
+  const [r, g, b] = [0, 2, 4]
+    .map(offset => parseInt(hex.substring(offset, offset + 2), 16) / 255)
+    .map(value => value <= 0.03928 
+      ? value / 12.92 
+      : Math.pow((value + 0.055) / 1.055, 2.4));
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Determines text color mode based on background brightness
+ * @param {string} backgroundColor - Background color in hex format
+ * @param {string} processor - Payment processor name
+ * @returns {string} Appropriate color mode for the processor
+ */
+function getTextColorMode(backgroundColor, processor) {
+  const luminance = calculateLuminance(backgroundColor);
+  const isLightBackground = luminance > 0.5;
+
+  // Different processors use different color mode naming
+  switch (processor.toLowerCase()) {
+    case 'paypal':
+      return isLightBackground ? 'black' : 'white';
+    case 'stripe':
+      return isLightBackground ? 'light' : 'dark';
+    default:
+      return isLightBackground ? 'light' : 'dark';
+  }
+}
+
+/**
+ * Gets the appropriate text color for Stripe elements
+ * @param {string} backgroundColor - Background color in hex
+ * @returns {string} Text color in hex
+ */
+function getStripeTextColors(backgroundColor) {
+  const luminance = calculateLuminance(backgroundColor);
+  const isLightBackground = luminance > 0.5;
+
+  // Use standard colors with PayPal for consistency
+  if (isPaypalPresent()) {
+    return isLightBackground ? '#000000' : '#FFFFFF';
+  } else {
+    return themeColors?.primaryTextColor || PAYMENT_CONFIG.DEFAULT_COLORS.text;
+  }
+}
+
+/**
+ * Gets Stripe appearance options with configurable text alignment
+ * @param {string} backgroundColor - Background color in hex
+ * @param {string} alignment - Text alignment value ('left', 'center', 'right')
+ * @returns {Object} Stripe appearance configuration
+ */
+function getStripeAppearanceOptions(backgroundColor, alignment = 'left') {
+  const fontConfig = getCustomFontConfig();
+  const fonts = fontConfig.cssSrc ? [{ cssSrc: fontConfig.cssSrc }] : [];
+  const fontFamily = fontConfig.family ? `${fontConfig.family}, system-ui, sans-serif` : 'system-ui, sans-serif';
+
+  return {
+    fonts,
+    appearance: {
+      variables: {
+        colorText: getStripeTextColors(backgroundColor),
+        logoColor: getTextColorMode(backgroundColor, 'stripe'),
+        fontFamily,
+        fontSizeBase: '16px',
+        fontSizeSm: '15px'
+      },
+      rules: { '.PaymentMethodMessaging': { textAlign: alignment } }
+    }
+  };
+}
+
+/**
+ * Gets font configuration for payment elements
+ * Custom fonts are only used for Stripe when PayPal isn't present
+ * @returns {Object} Font configuration with cssSrc and family properties
+ */
+function getCustomFontConfig() {
+  if (isPaypalPresent()) {
+    return { cssSrc: null, family: null };
+  }
+  
+  const fontData = window.bigcartel?.theme?.fonts?.primary_text_font;
+  return {
+    cssSrc: fontData?.url || null,
+    family: fontData?.name || null
+  };
+}
+
+/**
+ * Checks if PayPal is available for the shop
+ * @returns {boolean} Whether PayPal is configured
+ */
+function isPaypalPresent() {
+  return window.bigcartel?.checkout?.paypal_merchant_id && typeof PayPalSDK !== 'undefined';
+}
+
+/**
+ * Waits for content to appear with a polling approach
+ * @param {Function} checkFn - Function that returns true when content is found
+ * @param {Object} options - Configuration options
+ * @param {number} options.maxWaitTime - Maximum time to wait in ms
+ * @param {number} options.pollInterval - How often to check in ms
+ * @param {number} options.minRetries - Minimum number of retries to perform
+ * @param {string} options.context - Context identifier for logging
+ * @returns {Promise<boolean>} Whether content was found
+ */
+async function waitForContent(checkFn, options = {}) {
+  const maxWaitTime = options.maxWaitTime || 2000;
+  const pollInterval = options.pollInterval || 200;
+  const minRetries = options.minRetries || 0;
+  const context = options.context || 'Content';
+  
+  // Calculate how many attempts we'll make
+  const maxAttempts = Math.max(minRetries, Math.ceil(maxWaitTime / pollInterval));
+  let attempts = 0;
+  
+  // Start time for logging
+  const startTime = Date.now();
+  let contentFound = false;
+  
+  while (attempts < maxAttempts) {
+    // Check if content is available
+    const result = await checkFn();
+    if (result) {
+      contentFound = true;
+      
+      // If we've met our minimum retry count, exit early
+      if (attempts >= minRetries) {
+        break;
+      }
+    }
+    
+    // If this is the last attempt, don't wait anymore
+    if (attempts === maxAttempts - 1) {
+      break;
+    }
+    
+    // Wait for the next interval
+    await new Promise(resolve => setTimeout(resolve, pollInterval));
+    attempts++;
+  }
+
+  if (!contentFound) {
+    const elapsedTime = Date.now() - startTime;
+    console.warn(`[BNPL] ${context} content detection timed out after ${elapsedTime}ms (${attempts + 1} attempts)`);
+  }
+
+  return contentFound;
+}
+
+/**
+ * Core functions
+ */
+
+/**
+ * Displays Buy Now Pay Later messaging when available
+ * @param {number} price - Product price
+ * @param {Object} options - Optional configuration
+ * @param {string} options.alignment - Text alignment for messaging ('left', 'center', 'right')
+ * @param {string} options.displayMode - Display mode for parent container ('block', 'flex', etc.)
+ * @param {string} options.pageType - Page type for PayPal messaging ('product', 'cart')
+ */
+async function showBnplMessaging(price = null, options = {}) {
+  if (!themeOptions.showBnplMessaging) {
+    return;
+  }
+
+  // Get container elements
+  const parentContainer = document.getElementById(PAYMENT_CONFIG.PARENT_CONTAINER.containerId);
+  const stripeContainer = document.getElementById(PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.containerId);
+  const paypalContainer = document.getElementById(PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.containerId);
+
+  if (!parentContainer || !stripeContainer || !paypalContainer) {
+    return;
+  }
+
+  const finalPrice = validatePrice(price);
+  if (!finalPrice) {
+    console.info('[BNPL] Invalid price:', price);
+    return;
+  }
+
+  const colors = {
+    backgroundColor: themeColors?.backgroundColor || PAYMENT_CONFIG.DEFAULT_COLORS.background,
+    primaryTextColor: themeColors?.primaryTextColor || PAYMENT_CONFIG.DEFAULT_COLORS.text
+  };
+
+  // Use provided alignment or fall back to default
+  const alignment = options.alignment || PAYMENT_CONFIG.DEFAULT_ALIGNMENT;
+  
+  // Get the pageType value from options or use default
+  const pageTypeKey = options.pageType || 'default';
+  const pageType = PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.pageTypes[pageTypeKey] || 
+                    PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.pageTypes.default;
+  
+  // Handle display mode via CSS classes
+  const displayClass = options.displayMode ? `display-${options.displayMode}` : '';
+  
+  // Remove any existing display classes
+  const displayClassPattern = /\bdisplay-\S+/g;
+  parentContainer.className = parentContainer.className.replace(displayClassPattern, '');
+
+  const isStripeVisible = stripeContainer.style.height === 'auto' && stripeContainer.style.overflow === 'visible';
+  const isPaypalVisible = paypalContainer.style.height === 'auto' && paypalContainer.style.overflow === 'visible';
+  const isParentVisible = 
+    parentContainer.style.position === 'static' && 
+    !parentContainer.classList.contains('hidden') &&
+    parentContainer.style.left === 'auto' &&
+    parentContainer.style.top === 'auto';
+  const isUpdate = isParentVisible && (isStripeVisible || isPaypalVisible);
+
+  // Remove visibility classes initially
+  stripeContainer.classList.remove('visible');
+  paypalContainer.classList.remove('visible');
+  parentContainer.classList.remove('dual-messaging');
+
+  // Keep parent container out of the flow initially to prevent layout shifts
+  if (!isUpdate) {
+    // Keep parent container available but not affecting layout
+    parentContainer.style.position = 'absolute';
+    parentContainer.style.left = '-9999px';
+    parentContainer.style.top = '-9999px';
+    
+    // Initialize inner containers
+    stripeContainer.style.height = '0';
+    stripeContainer.style.overflow = 'hidden';
+    paypalContainer.style.height = '0';
+    paypalContainer.style.overflow = 'hidden';
+  }
+
+  // Initialize these variables before use
+  let paypalVisible = false;
+  let stripeVisible = false;
+
+  try {
+    // Process PayPal messaging
+    paypalVisible = await showPaypalMessaging(
+      finalPrice, 
+      colors, 
+      paypalContainer, 
+      isPaypalVisible, 
+      alignment, 
+      pageType
+    );
+    
+    // Process Stripe messaging with the provided alignment
+    if (isStripeVisible) {
+      // For updates, completely remount the Stripe element to preserve alignment
+      stripeVisible = await updateStripeMessaging(finalPrice, colors, stripeContainer, alignment);
+    } else {
+      // For initial detection, use fixed positioning technique
+      stripeVisible = await detectStripeWithExistingContainer(finalPrice, colors, stripeContainer, alignment);
+    }
+  } catch (error) {
+    console.error('Error processing messaging:', error);
+    // Continue with default values (false) if there's an error
+  }
+  
+  // Add visibility classes based on detection results
+  if (stripeVisible) {
+    stripeContainer.classList.add('visible');
+  }
+  
+  if (paypalVisible) {
+    paypalContainer.classList.add('visible');
+  }
+  
+  // If both are visible, add dual-messaging class to parent
+  if (stripeVisible && paypalVisible) {
+    parentContainer.classList.add('dual-messaging');
+  }
+  
+  // Only bring container on-screen if we have content
+  if (paypalVisible || stripeVisible) {
+    parentContainer.style.position = 'static';
+    parentContainer.style.left = 'auto';
+    parentContainer.style.top = 'auto';
+    parentContainer.classList.remove('hidden');
+    
+    // Re-apply display class here, after the container is positioned properly
+    if (displayClass) {
+      parentContainer.classList.add(displayClass);
+    }
+  } else {
+    parentContainer.style.display = 'none';
+  }
+}
+
+/**
+ * Detects if Stripe BNPL messaging is available for the current price
+ * Uses an off-screen container to avoid layout shifts during detection
+ * @param {number} price - Product price
+ * @param {Object} colors - Color settings
+ * @param {HTMLElement} container - Stripe container element
+ * @param {string} alignment - Text alignment for messaging
+ * @returns {Promise<boolean>} Whether Stripe has visible content
+ */
+async function detectStripeWithExistingContainer(price, { backgroundColor }, container, alignment = 'left') {
+  const elementId = PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.elementId;
+  const element = container.querySelector(`#${elementId}`);
+  const { bigcartel } = window;
+
+  if (!element || 
+    typeof Stripe !== 'function' || 
+    !bigcartel?.checkout?.stripe_publishable_key ||
+    !bigcartel?.account) {
+    return false;
+  }
+
+  try {        
+    // Keep the real container hidden during detection
+    container.style.height = '0';
+    container.style.overflow = 'hidden';
+    
+    // Create an invisible but technically rendered container to test if Stripe will show BNPL content
+    const tempContainer = document.createElement('div');
+    tempContainer.id = 'temp-stripe-container';
+    // Position off-screen but rendered to allow Stripe to properly evaluate
+    tempContainer.style.position = 'fixed';
+    tempContainer.style.bottom = '0';
+    tempContainer.style.right = '0';
+    tempContainer.style.width = '500px';
+    tempContainer.style.height = 'auto';
+    tempContainer.style.overflow = 'visible';
+    tempContainer.style.opacity = '0.01';
+    tempContainer.style.pointerEvents = 'none';
+    tempContainer.style.zIndex = '-1';
+    
+    // Create a temporary element for Stripe
+    const tempElement = document.createElement('div');
+    tempElement.id = 'temp-stripe-element';
+    tempContainer.appendChild(tempElement);
+    
+    // Add to document body
+    document.body.appendChild(tempContainer);
+    
+    // Initialize Stripe in the temp container
+    const stripe = Stripe(bigcartel.checkout.stripe_publishable_key);
+    
+    // Use the helper function to get appearance options with the provided alignment
+    const options = getStripeAppearanceOptions(backgroundColor, alignment);
+
+    const elements = stripe.elements(options);
+    const messagingParams = {
+      amount: price * 100,
+      currency: bigcartel.account.currency,
+      paymentMethodTypes: PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.paymentMethodTypes,
+      countryCode: bigcartel.account.country?.code
+    };
+
+    const messagingElement = elements.create('paymentMethodMessaging', messagingParams);
+    
+    await messagingElement.mount('#temp-stripe-element');
+    
+    // Define the check function that will be called repeatedly
+    const checkForContent = async () => {
+      const iframe = tempElement.querySelector('iframe');
+      if (!iframe) {
+        return false;
+      }
+      
+      const height = iframe.offsetHeight;
+      
+      // Check if the height indicates content
+      return height >= PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.heightThresholds.minVisibleHeight;
+    };
+    
+    // Wait for content with configured polling parameters
+    let hasContent = await waitForContent(checkForContent, {
+      maxWaitTime: PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.detection.maxWaitTime,
+      pollInterval: PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.detection.pollInterval,
+      minRetries: PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.detection.minRetries,
+      context: 'Stripe'
+    });
+    
+    // Cleanup temporary element
+    document.body.removeChild(tempContainer);
+    
+    // If we detected content, initialize the actual container and make it visible
+    if (hasContent) {      
+      // Clear the original element since we're mounting fresh
+      element.innerHTML = '';
+      
+      // Create and mount a new messaging element in the real container
+      const realElements = stripe.elements(options);
+      const realMessagingElement = realElements.create('paymentMethodMessaging', messagingParams);
+      await realMessagingElement.mount(`#${elementId}`);
+      
+      // Make the real container visible
+      container.style.height = 'auto';
+      container.style.overflow = 'visible';
+    }
+    
+    return hasContent;
+  } catch (error) {
+    console.warn('[BNPL] Error detecting Stripe messaging:', {
+      message: error.message,
+      name: error.name,
+      context: 'Detection phase'
+    });
+    
+    // Clean up temp container if it exists
+    const tempContainer = document.getElementById('temp-stripe-container');
+    if (tempContainer && tempContainer.parentNode) {
+      tempContainer.parentNode.removeChild(tempContainer);
+    }
+    
+    return false;
+  }
+}
+
+/**
+ * Updates existing Stripe messaging with complete DOM remount to preserve alignment
+ * This approach ensures alignment settings are properly applied during updates
+ * @param {number} price - Product price
+ * @param {Object} colors - Color settings
+ * @param {HTMLElement} container - Stripe container element
+ * @param {string} alignment - Text alignment for messaging
+ * @returns {Promise<boolean>} Whether messaging is visible
+ */
+async function updateStripeMessaging(price, { backgroundColor }, container, alignment = 'left') {
+  const elementId = PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.elementId;
+  const element = container.querySelector(`#${elementId}`);
+  
+  if (!element || typeof Stripe !== 'function') {
+    return false;
+  }
+
+  const { bigcartel } = window;
+  if (!bigcartel?.checkout?.stripe_publishable_key || !bigcartel.account) {
+    return false;
+  }
+
+  try {    
+    // First, remove the element completely from the DOM
+    const parentElement = element.parentNode;
+    parentElement.removeChild(element);
+    
+    // Create a new element with the same ID
+    const newElement = document.createElement('div');
+    newElement.id = elementId;
+    parentElement.appendChild(newElement);
+    
+    // Initialize Stripe with updated price on the new element
+    const stripe = Stripe(bigcartel.checkout.stripe_publishable_key);
+    const options = getStripeAppearanceOptions(backgroundColor, alignment);
+
+    const elements = stripe.elements(options);
+    const messagingParams = {
+      amount: price * 100,
+      currency: bigcartel.account.currency,
+      paymentMethodTypes: PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.paymentMethodTypes,
+      countryCode: bigcartel.account.country?.code
+    };
+
+    const messagingElement = elements.create('paymentMethodMessaging', messagingParams);
+    
+    // Mount to the new element
+    await messagingElement.mount(`#${elementId}`);
+    
+    // Add initialization timeout to ensure rendering completes
+    await new Promise(resolve => 
+      setTimeout(resolve, PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.timeouts.initialization * 1.5)
+    );
+    
+    // Check if iframe exists after remount
+    const iframe = newElement.querySelector('iframe');
+    if (!iframe) {
+      container.style.height = '0';
+      container.style.overflow = 'hidden';
+      return false;
+    }
+    
+    // Keep container visible
+    return true;
+  } catch (error) {
+    console.warn('[BNPL] Stripe messaging update error:', error);
+    return false;
+  }
+}
+
+/**
+ * Displays PayPal payment messaging
+ * @param {number} price - Product price
+ * @param {Object} colors - Display options
+ * @param {HTMLElement} container - Container element
+ * @param {boolean} isAlreadyVisible - Whether PayPal messaging is already visible
+ * @param {string} alignment - Text alignment ('left', 'center', 'right')
+ * @param {string} pageType - Page type for PayPal messaging ('product-details', 'cart')
+ * @returns {Promise<boolean>} Whether messaging is visible
+ */
+async function showPaypalMessaging(
+  price, 
+  { backgroundColor }, 
+  container, 
+  isAlreadyVisible = false, 
+  alignment = 'left', 
+  pageType = 'product-details'
+) {
+  const elementId = PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.elementId;
+  
+  if (!container || typeof PayPalSDK === 'undefined') {
+    return false;
+  }
+  
+  try {
+    // Clear container and create a fresh element to prevent PayPal SDK caching
+    container.innerHTML = '';
+    
+    const newElement = document.createElement('div');
+    newElement.id = elementId;
+    
+    // Add data attribute to ensure unique rendering context for PayPal SDK
+    newElement.setAttribute('data-rendering-id', Date.now());
+    container.appendChild(newElement);
+    newElement.style.display = 'block';
+    
+    let isVisible = false;
+    const message = PayPalSDK.Messages({
+      amount: price,
+      pageType: pageType,
+      style: {
+        layout: 'text',
+        logo: {
+          type: 'primary',
+          position: 'left'
+        },
+        text: {
+          color: getTextColorMode(backgroundColor, 'paypal'),
+          size: "14",
+          align: alignment
+        }
+      },
+      onRender: () => {
+        if (newElement.offsetHeight > 0) {
+          container.style.height = 'auto';
+          container.style.overflow = 'visible';
+          isVisible = true;
+        }
+      }
+    });
+
+    await message.render(`#${elementId}`);
+    await new Promise(resolve => setTimeout(resolve, PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.timeouts.render));
+
+    // Double-check visibility after rendering
+    if (!isVisible && newElement.offsetHeight > 0) {
+      container.style.height = 'auto';
+      container.style.overflow = 'visible';
+      isVisible = true;
+    }
+    
+    return isVisible;
+  } catch (error) {
+    console.warn('[BNPL] PayPal messaging error:', error);
+    return false;
+  }
+}

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -104,6 +104,7 @@ function enableAddButton(updated_price) {
   addButton.html(addButtonTitle + priceTitle);
   addButton.attr('aria-label',addButton.text());
   updateInventoryMessage($('#option').val());
+  showBnplMessaging(updated_price, { pageType: 'product' });
 }
 
 function disableAddButton(type) {
@@ -157,5 +158,11 @@ function disableSelectOption(select_option, type) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  updateInventoryMessage();
+  const isProductPage = document.body.getAttribute('data-bc-page-type') === 'product';
+  if (isProductPage) {
+    updateInventoryMessage();
+    
+    const price = window.bigcartel?.product?.default_price || null;    
+    showBnplMessaging(price, { pageType: 'product' });
+  }
 });

--- a/source/layout.html
+++ b/source/layout.html
@@ -67,7 +67,9 @@
             {% for page in pages.all limit: theme.nav_items %}
               <li class="header-page-link">{{ page | link_to }}</li>
             {% endfor %}
-            <li class="header-page-link"><a href="/contact">{{ pages.contact.name }}</a></li>
+            {% unless pages.all.size > 0 %}
+              <li class="header-page-link"><a href="/contact">{{ pages.contact.name }}</a></li>
+            {% endunless %}
           </ul>
         </nav>
 

--- a/source/layout.html
+++ b/source/layout.html
@@ -400,6 +400,15 @@
       </div>
     </div>
     <script>
+      {% comment %}
+        Manual array construction needed for Liquid 3.0.6 since standard JSON filters 
+        (json, jsonify) don't work properly. This ensures proper JavaScript array 
+        formatting with quoted elements and commas.
+      {% endcomment %}
+      const themeFeatures = {
+        optIns: [{% if theme.features.opt_ins %}{% for opt in theme.features.opt_ins %}"{{ opt }}"{% unless forloop.last %}, {% endunless %}{% endfor %}{% endif %}],
+        optOuts: [{% if theme.features.opt_outs %}{% for opt in theme.features.opt_outs %}"{{ opt }}"{% unless forloop.last %}, {% endunless %}{% endfor %}{% endif %}],
+      };
       const themeColors = {
         backgroundColor: '{{ theme.background_color }}',
         buttonBackgroundColor: '{{ theme.button_background_color }}',
@@ -409,7 +418,7 @@
         accentBackgroundColor: '{{ theme.accent_background_color }}',
         accentTextColor: '{{ theme.accent_text_color }}',
         accentPatternColor: '{{ theme.accent_pattern_color }}',
-      }
+      };
       const themeOptions = {
         showSoldOutOptions: {{ theme.show_sold_out_product_options }},
         showLowInventoryMessages: {{ theme.show_low_inventory_messages }},
@@ -423,7 +432,8 @@
         page: "{{ page.permalink }}",
         homepageSlideshowAutoplay: {{ theme.homepage_slideshow_autoplay }},
         homepageSlideshowSpeed: {{ theme.homepage_slideshow_speed }},
-      }
+        showBnplMessaging: {{ theme.show_bnpl_messaging }} && !themeFeatures.optOuts.includes("theme_bnpl_messaging"),
+      };
     </script>
     {% if theme.announcement_message_text != blank %}
       <script>

--- a/source/layout.html
+++ b/source/layout.html
@@ -122,7 +122,7 @@
             {% if theme.welcome_image != blank %}
               welcome-image
             {% endif %}
-            {% if theme.featured_items == 0 %}
+            {% if theme.featured_items == 0 and theme.image_sets.slideshow.size == 0 %}
               hide-featured
             {% endif %}
           {% endif %}
@@ -157,7 +157,7 @@
         {% endif %}
         <canvas id="repeating-pattern"></canvas>
       </div>
-      <section class="content{% if theme.featured_items == 0 and page.permalink == 'home' %} hide-featured{% endif %}">
+      <section class="content{% if theme.featured_items == 0 and page.permalink == 'home' and theme.image_sets.slideshow.size == 0 %} hide-featured{% endif %}">
         {% if page.category == 'custom' %}
           <h1 class="page-title">{{ page.name }}</h1>
           <div class="page-content custom-page">
@@ -421,6 +421,8 @@
         pattern_style: "{{ theme.pattern_style }}",
         store_name: "{{ store.name | escape }}",
         page: "{{ page.permalink }}",
+        homepageSlideshowAutoplay: {{ theme.homepage_slideshow_autoplay }},
+        homepageSlideshowSpeed: {{ theme.homepage_slideshow_speed }},
       }
     </script>
     {% if theme.announcement_message_text != blank %}

--- a/source/product.html
+++ b/source/product.html
@@ -148,6 +148,18 @@
           {% if hide_price == false and product_status != blank %}<span class="product-detail__separator">&mdash;</span>{% endif %}
           {% if product_status != blank %}<div class="product-detail__status">{{ product_status }}</div>{% endif %}
         </div>
+        {% if product.status == "active" and theme.show_bnpl_messaging %}
+          {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
+            <div id="payment-processor-messaging">
+              <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+                <div id="paypal-messaging-element"></div>
+              </div>
+              <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+                <div id="payment-method-messaging-element"></div>
+              </div>
+            </div>
+          {% endunless %}
+        {% endif %}
       </div>
       {% if product.status == 'active' %}
         <form method="post" class="product-form {% if theme.show_sold_out_product_options %}show-sold-out{% else %}hide-sold-out{% endif %}" action="/cart" accept-charset="utf8">

--- a/source/settings.json
+++ b/source/settings.json
@@ -13,6 +13,13 @@
       "description": "1200px by 800px images recommended"
     }
   ],
+  "image_sets": [
+    {
+      "variable": "slideshow",
+      "label": "Slideshow",
+      "description": "Adds slideshow to the homepage"
+    }
+  ],
   "preset_styles": {
     "preview": {
       "title_font": "primary_font",
@@ -653,50 +660,28 @@
       "description": "Pattern style for the accent background"
     },
     {
-      "variable": "show_related_products",
-      "label": "Show related products",
+      "variable": "homepage_slideshow_autoplay",
+      "label": "Auto-play homepage slideshow",
       "type": "boolean",
       "default": true,
-      "description": "Displays related products on the Product page"
+      "description": "Automatically advances slides in the homepage slideshow"
     },
     {
-      "variable": "related_products_header",
-      "label": "Related products header",
-      "type": "text",
-      "description": "Displays above related products on Products pages",
-      "default": "You might also like",
-      "requires": [
-        "show_related_products eq true"
-      ]
-    },
-    {
-      "variable": "related_products",
-      "label": "Related products",
+      "variable": "homepage_slideshow_speed",
+      "label": "Slideshow speed",
       "type": "select",
-      "options": "1..8",
-      "default": 3,
-      "description": "The maximum number of related products to show on Product pages",
+      "options": [
+        ["Slowest", 6000],
+        ["Slower", 5000],
+        ["Normal", 4000],
+        ["Faster", 3500],
+        ["Fastest", 3000]
+      ],
+      "default": 4000,
+      "description": "Controls how quickly slides advance in the auto-playing slideshow",
       "requires": [
-        "show_related_products eq true"
+        "homepage_slideshow_autoplay eq true"
       ]
-    },
-    {
-      "variable": "related_products_order",
-      "label": "Related products order",
-      "type": "select",
-      "options": "product_orders",
-      "default": "sales",
-      "description": "The order of related products on the Product pages",
-      "requires": [
-        "show_related_products eq true"
-      ]
-    },
-    {
-      "variable": "show_search",
-      "label": "Show search",
-      "type": "boolean",
-      "default": true,
-      "description": "Shows a search field"
     },
     {
       "variable": "collections",
@@ -745,6 +730,52 @@
       "type": "text",
       "description": "Displays underneath featured products and links to your Products Page",
       "default": "View all products"
+    },
+    {
+      "variable": "show_related_products",
+      "label": "Show related products",
+      "type": "boolean",
+      "default": true,
+      "description": "Displays related products on the Product page"
+    },
+    {
+      "variable": "related_products_header",
+      "label": "Related products header",
+      "type": "text",
+      "description": "Displays above related products on Products pages",
+      "default": "You might also like",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "related_products",
+      "label": "Related products",
+      "type": "select",
+      "options": "1..8",
+      "default": 3,
+      "description": "The maximum number of related products to show on Product pages",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "related_products_order",
+      "label": "Related products order",
+      "type": "select",
+      "options": "product_orders",
+      "default": "sales",
+      "description": "The order of related products on the Product pages",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "show_search",
+      "label": "Show search",
+      "type": "boolean",
+      "default": true,
+      "description": "Shows a search field"
     },
     {
       "variable": "max_products_per_row",

--- a/source/settings.json
+++ b/source/settings.json
@@ -753,7 +753,7 @@
       "label": "Related products",
       "type": "select",
       "options": "1..8",
-      "default": 3,
+      "default": 6,
       "description": "The maximum number of related products to show on Product pages",
       "requires": [
         "show_related_products eq true"

--- a/source/settings.json
+++ b/source/settings.json
@@ -450,7 +450,7 @@
               "badge_background_color_primary": "#C9A4C4",
               "badge_text_color_secondary": "#805B7B",
               "badge_background_color_secondary": "#E8D6E5",
-              "inventory_status_text_color": "#C9A4C4",
+              "inventory_status_text_color": "#805B7B",
               "link_text_color": "#805B7B",
               "link_hover_color": "#B893B2",
               "announcement_text_color": "#FFFFFF",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranger",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranger",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -126,8 +126,8 @@
           {
             "style_name": "Bold #1",
             "fonts": {
-              "primary_font": "Inknut Antiqua",
-              "secondary_font": "Source Sans Pro"
+              "primary_font": "Impact",
+              "secondary_font": "Work Sans"
             },
             "colors": {
               "background_color": "#5F0F40",
@@ -155,8 +155,8 @@
           {
             "style_name": "Bold #2",
             "fonts": {
-              "primary_font": "Chivo",
-              "secondary_font": "Sora"
+              "primary_font": "Rubik Dirt",
+              "secondary_font": "Open Sans"
             },
             "colors": {
               "background_color": "#F7B538",
@@ -184,8 +184,8 @@
           {
             "style_name": "Bold #3",
             "fonts": {
-              "primary_font": "Signika",
-              "secondary_font": "Signika"
+              "primary_font": "Doto",
+              "secondary_font": "Source Code Pro"
             },
             "colors": {
               "background_color": "#080808",
@@ -218,30 +218,30 @@
           {
             "style_name": "Playful #1",
             "fonts": {
-              "primary_font": "Quicksand",
-              "secondary_font": "BioRhyme"
+              "primary_font": "Over the Rainbow",
+              "secondary_font": "Open Sans"
             },
             "colors": {
-              "background_color": "#FF7171",
-              "content_background_color": "#FF8989",
-              "accent_background_color": "#FF7171",
-              "accent_text_color": "#FFFFFF",
-              "accent_pattern_color": "#FFD6D6",
-              "header_text_color": "#FFFFFF",
-              "primary_text_color": "#FFFFFF",
-              "secondary_text_color": "#FFD6D6",
-              "button_text_color": "#FF7171",
-              "button_background_color": "#4ECDC4",
-              "button_hover_background_color": "#44B5AE",
-              "badge_text_color_primary": "#FF7171",
-              "badge_background_color_primary": "#4ECDC4",
-              "badge_text_color_secondary": "#FFFFFF",
-              "badge_background_color_secondary": "#FFA1A1",
-              "inventory_status_text_color": "#4ECDC4",
-              "link_text_color": "#FFFFFF",
-              "link_hover_color": "#4ECDC4",
-              "announcement_text_color": "#FF7171",
-              "announcement_background_color": "#4ECDC4"
+              "background_color": "#FFECEF",
+              "content_background_color": "#FFF5F7",
+              "accent_background_color": "#FFECEF",
+              "accent_text_color": "#222222",
+              "accent_pattern_color": "#FFDCE1",
+              "header_text_color": "#222222",
+              "primary_text_color": "#222222",
+              "secondary_text_color": "#555555",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#FF6B8B",
+              "button_hover_background_color": "#FF4D73",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#FF6B8B",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#CDCDCD",
+              "inventory_status_text_color": "#FF4D73",
+              "link_text_color": "#222222",
+              "link_hover_color": "#FF6B8B",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#FF6B8B"
             }
           },
           {
@@ -368,8 +368,8 @@
           {
             "style_name": "Earthy #3",
             "fonts": {
-              "primary_font": "Andada Pro",
-              "secondary_font": "Work Sans"
+              "primary_font": "Inconsolata",
+              "secondary_font": "Inconsolata"
             },
             "colors": {
               "background_color": "#D7BBA8",

--- a/source/settings.json
+++ b/source/settings.json
@@ -730,6 +730,16 @@
       "description": "The number of items featured on the Home page"
     },
     {
+      "variable": "featured_header",
+      "label": "Featured items header",
+      "type": "text",
+      "description": "Displays above featured items on the Home page",
+      "default": "Featured",
+      "requires": [
+        "featured_items gt 0"
+      ]
+    },
+    {
       "variable": "all_products_button_text",
       "label": "All products button text",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -950,6 +950,13 @@
       "description": "Sets the display of prices in your shop"
     },
     {
+      "variable": "show_bnpl_messaging",
+      "label": "Buy Now, Pay Later Messaging",
+      "type": "boolean",
+      "default": true,
+      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan."
+    },
+    {
       "variable": "instagram_url",
       "label": "Instagram URL",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -41,7 +41,7 @@
               "background_color": "#EEEEEE",
               "content_background_color": "#FFFFFF",
               "accent_background_color": "#000000",
-              "accent_text_color": "#FFFFFF",
+              "accent_text_color": "#EEEEEE",
               "accent_pattern_color": "#555555",
               "header_text_color": "#222222",
               "primary_text_color": "#222222",
@@ -521,7 +521,7 @@
     {
       "variable": "accent_text_color",
       "label": "Accent text",
-      "default": "#FFFFFF"
+      "default": "#EEEEEE"
     },
     {
       "variable": "accent_pattern_color",

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -1,4 +1,7 @@
-
+\:root
+  --pagination-background: transparent
+  --pagination-page-background: var(--primary-text-color)
+  --pagination-active-page: var(--primary-text-color)
 
 +keyframes(fade-in-load)
   0%
@@ -6,6 +9,48 @@
 
   100%
     opacity: 1
+
+.home-slideshow
+  margin-bottom: 48px
+
+  .slideshow-image
+    border-radius: var(--border-radius)
+    width: 100%
+
+  .splide__arrow
+    border-radius: var(--border-radius)
+    width: 2em
+    height: 3em
+
+  .splide__pagination
+    z-index: 1
+    background: var(--pagination-background)
+    border-radius: 18px
+    display: inline-flex
+    position: relative
+    margin-top: 8px
+    bottom: auto
+    align-items: center
+    justify-content: center
+    transform: translateX(-50%)
+    left: 50%
+    padding: 4px 8px
+    gap: 2px
+    right: auto
+
+    li
+      display: flex
+
+    .splide__pagination__page
+      opacity: 1
+      background: none
+      border: 1px solid var(--pagination-page-background)
+      height: 10px
+      width: 10px
+
+      &.is-active
+        background: var(--pagination-active-page)
+        transform: scale(1.1)
 
 .welcome-text
   color: var(--accent-text-color)

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -13,6 +13,9 @@
 .home-slideshow
   margin-bottom: 48px
 
+  .splide__slide
+    width: 100%
+
   .slideshow-image
     border-radius: var(--border-radius)
     width: 100%

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -18,6 +18,17 @@
   text-transform: uppercase
   z-index: 2
 
+h1.featured-title
+  color: var(--primary-text-color)
+  font-size: 2em
+  margin: 32px auto
+  text-align: center
+
+  @media screen and (max-width: $break-small)
+    color: var(--primary-text-color)
+    font-size: 1.5em
+    margin: 24px auto
+
 h1.welcome-header
   color: var(--accent-text-color)
   font-size: 60px

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -136,3 +136,6 @@ a.all-products-button
 
   svg
     fill: currentColor
+
+  &:not(:disabled):hover, &:not(:disabled):active
+    border: 2px solid var(--button-hover-background-color)

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -298,7 +298,7 @@ footer
     margin-left: auto
 
     @media screen and (max-width: $break-medium)
-      margin: 0 auto
+      margin: 32px auto 0
       width: 100%
       text-align: center
     

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -451,6 +451,12 @@ footer
 
     &:hover, &:focus
       color: var(--link-hover-color)
+  
+  img
+    display: inline-block
+    max-width: 100%
+    margin: 0 auto
+    padding-bottom: 16px
 
   @media screen and (max-width: $break-medium)
     padding: 32px

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -13,7 +13,7 @@ body
   +flex-direction(column)
   background-color: var(--background-color)
   color: var(--primary-text-color)
-  font-family: var(--primary-font)
+  font-family: var(--secondary-font)
   font-size: 16px
   line-height: 1.5
   margin: 0
@@ -62,6 +62,7 @@ a
     color: var(--link-hover-color)
 
 h1, h2, h3, h4, h5, h6
+  font-family: var(--primary-font)
   color: var(--primary-text-color)
   font-weight: 500
   margin: 0

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -346,8 +346,15 @@ footer
         width: 86px
 
 .footer-custom-content
+  display: grid
+  grid-template-columns: 1fr
+  justify-content: center
   text-align: center
   padding: 10px 16px 40px 16px
+  gap: 20px
+
+  > *
+    justify-self: center
 
 .footernav
   display: flex

--- a/source/stylesheets/maintenance.sass
+++ b/source/stylesheets/maintenance.sass
@@ -25,6 +25,7 @@
       padding-right: 16px
 
     h1.store-name
+      font-family: var(--primary-font)
       font-size: 2em
       margin: 0 0 16px 0
       height: auto

--- a/source/stylesheets/navigation.sass
+++ b/source/stylesheets/navigation.sass
@@ -33,13 +33,13 @@ header
     min-height: 100%
     align-items: center
     grid-template-columns: 1fr auto 1fr
-    gap: 24px
+    gap: 10px
 
     @media screen and (max-width: $break-large)
       padding: 0 32px
 
     @media screen and (max-width: $break-small)
-      grid-template-columns: 1fr 2fr 1fr
+      grid-template-columns: 0.75fr 2.5fr 0.75fr
       padding: 0 16px
 
 .category-nav

--- a/source/stylesheets/navigation.sass
+++ b/source/stylesheets/navigation.sass
@@ -210,7 +210,7 @@ header
 
   .header-pages
     display: flex
-    column-gap: 32px
+    column-gap: 24px
     row-gap: 4px
     flex-wrap: wrap
     list-style: none

--- a/source/stylesheets/navigation.sass
+++ b/source/stylesheets/navigation.sass
@@ -130,6 +130,7 @@ header
         padding: 8px
 
 .store-name
+  font-family: var(--primary-font)
   font-size: 2em
   display: flex
   height: var(--header-height)

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -12,7 +12,7 @@ section.content
       padding: var(--med-padding) var(--small-padding)
 
 .product-breadcrumb
-  margin-bottom: 16px
+  margin-bottom: 24px
   display: flex
   align-items: center
   justify-content: flex-start

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -135,9 +135,6 @@ section.content
     margin: 0
     text-align: left
 
-    @media screen and (max-width: $break-medium)
-      font-size: 1.5em
-
 .related-products-container
   margin-top: 100px
 

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -131,8 +131,12 @@ section.content
 
   h1.page-title
     color: var(--primary-text-color)
+    font-size: 1.75em
     margin: 0
     text-align: left
+
+    @media screen and (max-width: $break-medium)
+      font-size: 1.5em
 
 .related-products-container
   margin-top: 100px

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -123,6 +123,12 @@ section.content
       &:hover, &:focus
         color: var(--link-hover-color)
 
+    img
+      display: inline-block
+      max-width: 100%
+      margin: 0 auto
+      padding-bottom: 16px
+
   h1.page-title
     color: var(--primary-text-color)
     margin: 0

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -161,3 +161,36 @@ section.content
   text-align: center
   padding: 8px 0
   font-weight: 500
+
+#payment-processor-messaging
+  margin: 20px 0 0
+  width: 100%
+  display: block
+  
+  body[data-bc-page-type="cart"] &
+    margin-bottom: 40px
+
+  &.display-flex
+    display: flex
+    flex-direction: column
+    justify-content: center
+    align-items: center
+
+    &.dual-messaging
+      gap: 15x
+
+  &.display-grid
+    display: grid
+  
+  &.hidden
+    position: absolute
+    left: -9999px
+    top: -9999px
+
+  > div
+    margin-bottom: 0
+  
+  // Only apply the margin for non-flex layouts when dual messaging is present
+  &:not(.display-flex)
+    &.dual-messaging > div.visible:first-of-type
+      margin-bottom: 15px

--- a/source/theme.js
+++ b/source/theme.js
@@ -1,5 +1,6 @@
 //= require_directory ./javascripts/vendor
 //= require javascripts/functions
+//= require javascripts/product-payment-messaging
 //= require javascripts/product
 //= require javascripts/store
 //= require javascripts/navigation

--- a/source/theme.js
+++ b/source/theme.js
@@ -2,8 +2,9 @@
 //= require javascripts/functions
 //= require javascripts/product
 //= require javascripts/store
-//= require javascripts/navigation.js
-//= require javascripts/product-option-groups.js
-//= require javascripts/product-carousel.js
+//= require javascripts/navigation
+//= require javascripts/product-option-groups
+//= require javascripts/product-carousel
+//= require javascripts/home-carousel
 //= require javascripts/cart
 //= require javascripts/search


### PR DESCRIPTION
- feat: BNPL messaging on product and cart pages
- feat: featured heading on homepage
- feat: homepage slideshow
- fix: custom footer now centers multi-line content 
- fix: Classic 1 and Dreamy 2 preset color tweak for legibility
- fix: allow images to be centered on custom pages and product descriptions
- fix: only headings should use primary font 
- chore: tweak all products button styling on homepage
- chore: change default related product count from 4 to 6
- chore: tweak product title on mobile breakpoint
- chore: increase top margin of big cartel credit in footer on smaller brekapoint
- chore: increase bottom margin on breadcrumb on product pages
- chore: only show contact in desktop header if no custom pages
- chore: tighten up column gap in header
- chore: polish up preset styles, new font pairings