### PR TITLE
Ranger v2.11.5

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -21,16 +21,24 @@
 {% if theme.nav_page_display == "contact_only" %}
   {% assign show_more_menu = true %}
   {% assign show_more_menu_footer = true %}
-{% elsif theme.nav_page_display == "all" and pages.custom_pages.size > 0 %}
+{% elsif theme.nav_page_display == "all" and pages.custom_pages.size > 0 and theme.nav_items > 0 %}
   {% assign show_more_menu = true %}
+{% elsif theme.nav_page_display == "pages_only" and pages.custom_pages.size > 0 and theme.nav_items > 0 %}
+  {% assign show_more_menu = true %}
+{% endif %}
+
+{% if theme.nav_page_display_footer == "all" and pages.custom_pages.size > 0 and theme.nav_items_footer > 0 %}
   {% assign show_more_menu_footer = true %}
-{% elsif theme.nav_page_display == "pages_only" and pages.custom_pages.size > 0 %}
+{% elsif theme.nav_page_display_footer == "pages_only" and pages.custom_pages.size > 0 and theme.nav_items_footer > 0 %}
+  {% assign show_more_menu_footer = true %}
+{% endif %}
+
+{% if pages.subscribe_page %}
   {% assign show_more_menu = true %}
   {% assign show_more_menu_footer = true %}
 {% endif %}
 
 {% if store.website != blank %}
-  {% assign show_more_menu = true %}
   {% assign show_more_menu_footer = true %}
 {% endif %}
 

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranger",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "images": [
     {
       "variable": "logo_image",


### PR DESCRIPTION
Fixes bug where "More" dropdown would show with no content when:
- nav_page_display is "pages_only"
- No custom pages exist OR nav_items is set to 0
- No subscribe page exists

Separated header and footer logic to properly account for:
- Header: custom pages (with nav_items limit), subscribe, contact
- Footer: custom pages (with nav_items_footer limit), subscribe, contact,
  website, required pages

The dropdown now only displays when actual navigation links will render.